### PR TITLE
Encapsulate HTTP responses when using persistent requests

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -313,6 +313,8 @@ int start_play(streams *sid, sockets *s)
 		s->flush_enqued_data = 1;
 	sid->do_play = 1;
 	sid->start_streaming = 0;
+	if (s->type != TYPE_HTTP)
+		sid->start_streaming = 0;
 	sid->tp.apids = sid->tp.dpids = sid->tp.pids = sid->tp.x_pmt = NULL;
 
 	ad = get_adapter(sid->adapter);
@@ -349,6 +351,7 @@ int close_stream(int i)
 	}
 	mutex_lock(&st_mutex);
 	sid->enabled = 0;
+	sid->start_streaming = 0;
 	sid->timeout = 0;
 	ad = sid->adapter;
 	sid->adapter = -1;
@@ -741,7 +744,14 @@ void flush_streamb(streams *sid, unsigned char *buf, int rlen, int64_t ctime)
 	int i, rv = 0, blen, len;
 
 	if (sid->type == STREAM_HTTP)
+	{
 		rv = sockets_write(sid->rsock_id, buf, rlen);
+		if (sid->start_streaming == 0)
+		{
+			sid->start_streaming = 1;
+			LOG("Start HTTP streaming of stream %d to handle %d", sid->sid, sid->rsock);
+		}
+	}
 	else
 	{
 		int max_pack = sid->type == STREAM_RTSP_TCP ? sid->max_iov : UDP_MAX_PACK;
@@ -769,7 +779,14 @@ int flush_streami(streams *sid, int64_t ctime)
 	int rv;
 
 	if (sid->type == STREAM_HTTP)
+	{
 		rv = sockets_writev(sid->rsock_id, sid->iov, sid->iiov);
+		if (sid->start_streaming == 0)
+		{
+			sid->start_streaming = 1;
+			LOG("Start HTTP streaming of stream %d to handle %d", sid->sid, sid->rsock);
+		}
+	}
 	else
 		rv = send_rtp(sid, sid->iov, sid->iiov);
 


### PR DESCRIPTION
When using the HTTP protocol for streaming, it's possible to process multiple requests (aka Persistent Mode). And this is great! However, when doing the streaming the HTTP response is sended in between of the TS packets. Then it's possible to "encapsulate" the response inside a NULL TS packet.

This patch implements this and allows the client to change pids or request new streams without interrupting the streaming.