### PR TITLE
Fix no TEARDOWN with satipc module (v.2)

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -821,6 +821,8 @@ void close_adapter_for_stream(int sid, int aid)
 		ad->master_sid = -1;
 		mark_pids_deleted(aid, -1, NULL);
 		init_dvb_parameters(&ad->tp);
+		if (ad->standby)
+			ad->standby(ad);
 #ifdef AXE
 		free_axe_input(ad);
 #endif

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -21,6 +21,7 @@ typedef int (*Adapter_commit)(void *ad);
 typedef int (*Open_device)(void *ad);
 typedef int (*Device_signal)(void *ad);
 typedef int (*Device_wakeup)(void *ad, int fd, int voltage);
+typedef int (*Device_standby)(void *ad);
 typedef int (*Tune)(int aid, transponder *tp);
 typedef uint8_t (*Dvb_delsys)(int aid, int fd,
 							  uint8_t *sys);
@@ -106,6 +107,7 @@ typedef struct struct_adapter
 	Dvb_delsys delsys;
 	Device_signal get_signal;
 	Device_wakeup wakeup;
+	Device_standby standby;
 	Adapter_commit post_init, close;
 } adapter;
 

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -497,16 +497,12 @@ void satip_close_device(adapter *ad)
 	if (!sip)
 		return;
 
+	LOG("satip device %s:%d is closing", sip->sip, sip->sport);
 	if (sip->sleep)
 		LOGM("satip device %s:%d sleeping, so not sending the TEARDOWN message", sip->sip, sip->sport);
 	else
-	{
-		LOG("satip device %s:%d is closing", sip->sip, sip->sport);
 		http_request(ad, NULL, "TEARDOWN");
-	}
 	sip->sleep = 0;
-
-	http_request(ad, NULL, "TEARDOWN");
 	sip->session[0] = 0;
 	sip->sent_transport = 0;
 	if (ad->fe_sock > 0)
@@ -528,14 +524,11 @@ void satip_standby_device(adapter *ad)
 	if (!sip)
 		return;
 
+	LOG("satip device %s:%d going to standby sleep", sip->sip, sip->sport);
 	if (sip->sleep)
-	{
 		LOGM("satip device %s:%d already sleeping in standby", sip->sip, sip->sport);
-		return;
-	}
-
-	LOG("satip device %s:%d going to sleep standby", sip->sip, sip->sport);
-	http_request(ad, NULL, "TEARDOWN");
+	else
+		http_request(ad, NULL, "TEARDOWN");
 	sip->sleep = 1;
 	sip->session[0] = 0;
 }

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -68,6 +68,7 @@ typedef struct struct_satipc
 	int sport;
 	char session[18];
 	int stream_id;
+	int sleep;
 	int listen_rtp;
 	int rtcp, rtcp_sock, cseq;
 	int wp, qp;			 // written packet, queued packet
@@ -463,7 +464,7 @@ int satipc_open_device(adapter *ad)
 	sip->expect_reply = 0;
 	sip->last_connect = 0;
 	sip->sent_transport = 0;
-	sip->session[0] = 0;
+	sip->sleep = 0;
 	sip->stream_id = -1;
 	sip->wp = sip->qp = sip->want_commit = 0;
 	sip->rcvp = sip->repno = 0;
@@ -495,7 +496,16 @@ void satip_close_device(adapter *ad)
 	satipc *sip = get_satip(ad->id);
 	if (!sip)
 		return;
-	LOG("satip device %s:%d is closing", sip->sip, sip->sport);
+
+	if (sip->sleep)
+		LOGM("satip device %s:%d sleeping, so not sending the TEARDOWN message", sip->sip, sip->sport);
+	else
+	{
+		LOG("satip device %s:%d is closing", sip->sip, sip->sport);
+		http_request(ad, NULL, "TEARDOWN");
+	}
+	sip->sleep = 0;
+
 	http_request(ad, NULL, "TEARDOWN");
 	sip->session[0] = 0;
 	sip->sent_transport = 0;
@@ -506,6 +516,28 @@ void satip_close_device(adapter *ad)
 	ad->fe_sock = -1;
 	sip->rtcp_sock = -1;
 	sip->enabled = 0;
+}
+
+void satip_standby_device(adapter *ad)
+{
+	satipc *sip;
+	if (!ad)
+		return;
+
+	sip = get_satip(ad->id);
+	if (!sip)
+		return;
+
+	if (sip->sleep)
+	{
+		LOGM("satip device %s:%d already sleeping in standby", sip->sip, sip->sport);
+		return;
+	}
+
+	LOG("satip device %s:%d going to sleep standby", sip->sip, sip->sport);
+	http_request(ad, NULL, "TEARDOWN");
+	sip->sleep = 1;
+	sip->session[0] = 0;
 }
 
 int satipc_read(int socket, void *buf, int len, sockets *ss, int *rb)
@@ -1071,8 +1103,8 @@ void satipc_commit(adapter *ad)
 
 	url[0] = 0;
 	LOG(
-		"satipc: commit for adapter %d pids to add %d, pids to delete %d, expect_reply %d, force_commit %d want_tune %d do_tune %d, force_pids %d, sent_transport %d",
-		ad->id, sip->lap, sip->ldp, sip->expect_reply, sip->force_commit, sip->want_tune, ad->do_tune, sip->force_pids, sip->sent_transport);
+		"satipc: commit for adapter %d pids to add %d, pids to delete %d, expect_reply %d, force_commit %d want_tune %d do_tune %d, force_pids %d, sent_transport %d, sleep %d",
+		ad->id, sip->lap, sip->ldp, sip->expect_reply, sip->force_commit, sip->want_tune, ad->do_tune, sip->force_pids, sip->sent_transport, sip->sleep);
 
 	if (ad->do_tune && !sip->want_tune)
 	{
@@ -1230,6 +1262,7 @@ void satipc_commit(adapter *ad)
 		sip->force_commit = 0;
 	}
 
+	sip->sleep = 0;
 	http_request(ad, url, NULL);
 
 	return;
@@ -1321,6 +1354,7 @@ int add_satip_server(char *host, int port, int fe, char delsys, char *source_ip,
 	ad->tune = (Tune)satipc_tune;
 	ad->delsys = (Dvb_delsys)satipc_delsys;
 	ad->post_init = (Adapter_commit)satip_post_init;
+	ad->standby = (Device_standby)satip_standby_device;
 	ad->close = (Adapter_commit)satip_close_device;
 	ad->type = ADAPTER_SATIP;
 


### PR DESCRIPTION
This patch implements a new _optional_ adapter callback function named `standby()`. This function is called when the adapter doesn't have any stream clients running. This function is previous to the `close()` adapter. The expected behaviour is to put the tuner in a standby sleep for a fast restart in the future.

This new functionality is used  in the `satipc` module. With the new functionality when the last client sends a TEARDOWN command, the module sends a TEARDOWN to the remote SAT>IP server, but it doesn't close the connection. Then any new tuning command from a SAT>IP client can be served instantly.  In any case, when the timeout of the adapter is reached, then the adapter is closed definitively.

This PR supersedes  #728.
