### PR TITLE
Limit adapters to specific sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ Help
 
 * -j --jess jess_string - same format as -u 
 
+* -U --sources sources_for_adapters: select the adapters for each source
+       * eg: -U 0-2:*:3:1,5,7 (no spaces between parameters)
+       - In this example: for SRC=1 only 0,1,2; for SRC=2 all: for SRC=3 only 3; and for SRC=4 the 1,5,7 adapters.
+       - For each position (separated by : ) you need to declare all the adapters that use this position
+       - The special char * indicates all adapters for this position
+       - If errors or by default all adapters have enabled all positions
+
+
 * -w --http-host http_server[:port]: specify the host and the port (if not 80) where the xml file can be downloaded from [default: default_local_ip_address:8080] 
 	* eg: -w 192.168.1.1:8080 
 

--- a/README.md
+++ b/README.md
@@ -190,13 +190,13 @@ Help
 
 * -j --jess jess_string - same format as -u 
 
-* -U --sources sources_for_adapters: select the adapters for each source
-       * eg: -U 0-2:*:3:1,5,7 (no spaces between parameters)
-       - In this example: for SRC=1 only 0,1,2; for SRC=2 all: for SRC=3 only 3; and for SRC=4 the 1,5,7 adapters.
-       - For each position (separated by : ) you need to declare all the adapters that use this position
-       - The special char * indicates all adapters for this position
-       - If errors or by default all adapters have enabled all positions
-
+* -U --sources sources_for_adapters: limit the adapters to specific sources/positions
+	* eg: -U 0-2:*:3:2,6,8 (no spaces between parameters)
+	- In this example: for SRC=1 only 0,1,2; for SRC=2 all; for SRC=3 only 3; and for SRC=4 the 2,6,8 adapters are used.
+	- For each position (separated by : ) you need to declare all the adapters that use this position with no exception.
+	- The special char * indicates all adapters for this position.
+	- The number of sources range from 1 to 64; but the list can include less than 64 (in this case all are enabled for undefined sources). 
+	- By default or in case of errors all adapters have enabled all positions.
 
 * -w --http-host http_server[:port]: specify the host and the port (if not 80) where the xml file can be downloaded from [default: default_local_ip_address:8080] 
 	* eg: -w 192.168.1.1:8080 

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -1654,80 +1654,80 @@ void set_diseqc_adapters(char *o)
 
 void set_sources_adapters(char *o)
 {
-       int i, la, lb, st, end, j, k, adap;
-       uint64_t all = 0xFFFFFFFFFFFFFFFF;
-       char buf[1024], *arg[128], *sep;
-       SAFE_STRCPY(buf, o);
-       for (i = 0; i < MAX_ADAPTERS; i++)
-               all = (all << 1) + 1;
-       la = split(arg, buf, ARRAY_SIZE(arg), ':');
-       if ((la == 1 && strlen(arg[0]) == 0) || la < 1 || la > MAX_SOURCES)
-               goto ERR;
+	int i, la, lb, st, end, j, k, adap;
+	uint64_t all = 0xFFFFFFFFFFFFFFFF;
+	char buf[1024], *arg[128], *sep;
+	SAFE_STRCPY(buf, o);
+	for (i = 0; i < MAX_ADAPTERS; i++)
+		all = (all << 1) + 1;
+	la = split(arg, buf, ARRAY_SIZE(arg), ':');
+	if ((la == 1 && strlen(arg[0]) == 0) || la < 1 || la > MAX_SOURCES)
+		goto ERR;
 
-       LOG("Calculating adapter sources: [%s] ", o);
-       for (i = 0; i < MAX_SOURCES; i++)
-       {
-               if (i >= la)
-               {
-                       LOGM(" src=%d undefined, using all", i + 1);
-                       source_map[i] = all;
-                       continue;
-               }
+	LOG("Calculating adapter sources: [%s] ", o);
+	for (i = 0; i < MAX_SOURCES; i++)
+	{
+		if (i >= la)
+		{
+			LOGM(" src=%d undefined, using all", i + 1);
+			source_map[i] = all;
+			continue;
+		}
 
-               source_map[i] = 0;
-               if (arg[i] && arg[i][0] == '*')
-               {
-                       if (strlen(arg[i]) != 1)
-                               goto ERR;
-                       source_map[i] = all;
-                       char buf2[128];
-                       buf2[0]='\0';
-                       for (j = 1; j <= (la > MAX_ADAPTERS ? MAX_ADAPTERS : la); j++)
-                               strcat(buf2, "X");
-                       LOGM(" src=%d using adapters %s (%lu)", i + 1, buf2, (unsigned long)source_map[i]);
-                       continue;
-               }
-               char buf2[128], *arg2[128];
-               SAFE_STRCPY(buf2, arg[i]);
-               lb = split(arg2, buf2, ARRAY_SIZE(arg2), ',');
-               for (j = 0; j < lb; j++)
-               {
-                       sep = strchr(arg2[j], '-');
-                       if (sep == NULL)
-                       {
-                               adap = map_int(arg2[j], NULL);
-                               if (adap <= 0 || adap > MAX_ADAPTERS)
-                                       goto ERR;
-                               source_map[i] |= (unsigned long)1 << (adap - 1);
-                       }
-                       else
-                       {
-                               st = map_int(arg2[j], NULL);
-                               end = map_int(sep + 1, NULL);
-                               if (st <= 0 || end <= 0 || st > MAX_ADAPTERS || end > MAX_ADAPTERS || end < st)
-                                       goto ERR;
-                               for (k = st; k <= end; k++)
-                               {
-                                       adap = k;
-                                       source_map[i] |= (unsigned long)1 << (adap - 1);
-                               }
-                       }
-               }
-               buf2[0]='\0';
-               for (j = 1; j <= (la > MAX_ADAPTERS ? MAX_ADAPTERS : la); j++)
-                       if (source_map[i] & ((unsigned long)1 << (j - 1)))
-                               strcat(buf2, "X");
-                       else
-                               strcat(buf2, ".");
-               LOGM(" src=%d using adapters %s (%lu)", i + 1, buf2, (unsigned long)source_map[i]);
-       }
-       LOG("Adapter correct sources format");
-       return;
+		source_map[i] = 0;
+		if (arg[i] && arg[i][0] == '*')
+		{
+			if (strlen(arg[i]) != 1)
+				goto ERR;
+			source_map[i] = all;
+			char buf2[128];
+			buf2[0]='\0';
+			for (j = 1; j <= (la > MAX_ADAPTERS ? MAX_ADAPTERS : la); j++)
+				strcat(buf2, "X");
+			LOGM(" src=%d using adapters %s (%lu)", i + 1, buf2, (unsigned long)source_map[i]);
+			continue;
+		}
+		char buf2[128], *arg2[128];
+		SAFE_STRCPY(buf2, arg[i]);
+		lb = split(arg2, buf2, ARRAY_SIZE(arg2), ',');
+		for (j = 0; j < lb; j++)
+		{
+			sep = strchr(arg2[j], '-');
+			if (sep == NULL)
+			{
+				adap = map_int(arg2[j], NULL);
+				if (adap <= 0 || adap > MAX_ADAPTERS)
+					goto ERR;
+				source_map[i] |= (unsigned long)1 << (adap - 1);
+			}
+			else
+			{
+				st = map_int(arg2[j], NULL);
+				end = map_int(sep + 1, NULL);
+				if (st <= 0 || end <= 0 || st > MAX_ADAPTERS || end > MAX_ADAPTERS || end < st)
+					goto ERR;
+				for (k = st; k <= end; k++)
+				{
+					adap = k;
+					source_map[i] |= (unsigned long)1 << (adap - 1);
+				}
+			}
+		}
+		buf2[0]='\0';
+		for (j = 1; j <= (la > MAX_ADAPTERS ? MAX_ADAPTERS : la); j++)
+			if (source_map[i] & ((unsigned long)1 << (j - 1)))
+				strcat(buf2, "X");
+			else
+				strcat(buf2, ".");
+		LOGM(" src=%d using adapters %s (%lu)", i + 1, buf2, (unsigned long)source_map[i]);
+	}
+	LOG("Adapter correct sources format parameter");
+	return;
 
 ERR:
-       for (i = 0; i < MAX_SOURCES; i++)
-               source_map[i] = all;
-       LOG("Adapter sources format %s, using defaults for all adapters!", strlen(arg[0]) > 0 ? "incorrect" : "missing");
+	for (i = 0; i < MAX_SOURCES; i++)
+		source_map[i] = all;
+	LOG("Adapter sources format parameter %s, using defaults for all adapters!", strlen(arg[0]) > 0 ? "incorrect" : "missing");
 }
 
 

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -509,10 +509,10 @@ int getAdaptersCount()
 	for (i = 0; i < MAX_ADAPTERS; i++)
 		if ((ad = a[i]))
 		{
-			// Note: Adapter 1 uses bit 0, and source_map uses ranges from 0..SRC-1
-			if (i > 0) for (j = 1; j <= MAX_SOURCES; j++)
+			// Note: Adapter 0 uses map bit 0, and source_map uses ranges from 0..SRC-1 (SRC=0 can't be configured)
+			for (j = 0; j < MAX_SOURCES; j++)
 			{
-				ad->sources_pos[j] = (source_map[j-1] >> (i - 1)) & 1;
+				ad->sources_pos[j] = (source_map[j-1] >> i) & 1;
 			}
 
 			if (!opts.force_sadapter && (delsys_match(ad, SYS_DVBS) || delsys_match(ad, SYS_DVBS2)))
@@ -749,7 +749,7 @@ int get_free_adapter(transponder *tp)
 	}
 	// provide an already existing adapter
 	for (i = 0; i < MAX_ADAPTERS; i++)
-		if ((ad = get_adapter_nw(i)) && delsys_match(ad, msys))
+		if ((ad = get_adapter_nw(i)) && delsys_match(ad, msys) && ad->sources_pos[tp->diseqc])
 			if (!compare_tunning_parameters(ad->id, tp))
 				return i;
 

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -1658,8 +1658,6 @@ void set_sources_adapters(char *o)
 	uint64_t all = 0xFFFFFFFFFFFFFFFF;
 	char buf[1024], *arg[128], *sep;
 	SAFE_STRCPY(buf, o);
-	for (i = 0; i < MAX_ADAPTERS; i++)
-		all = (all << 1) + 1;
 	la = split(arg, buf, ARRAY_SIZE(arg), ':');
 	if ((la == 1 && strlen(arg[0]) == 0) || la < 1 || la > MAX_SOURCES)
 		goto ERR;
@@ -1682,7 +1680,7 @@ void set_sources_adapters(char *o)
 			source_map[i] = all;
 			char buf2[128];
 			buf2[0]='\0';
-			for (j = 1; j <= (la > MAX_ADAPTERS ? MAX_ADAPTERS : la); j++)
+			for (j = 0; j < MAX_ADAPTERS; j++)
 				strcat(buf2, "X");
 			LOGM(" src=%d using adapters %s (%lu)", i + 1, buf2, (unsigned long)source_map[i]);
 			continue;
@@ -1696,26 +1694,26 @@ void set_sources_adapters(char *o)
 			if (sep == NULL)
 			{
 				adap = map_int(arg2[j], NULL);
-				if (adap <= 0 || adap > MAX_ADAPTERS)
+				if (adap < 0 || adap >= MAX_ADAPTERS)
 					goto ERR;
-				source_map[i] |= (unsigned long)1 << (adap - 1);
+				source_map[i] |= (unsigned long)1 << adap;
 			}
 			else
 			{
 				st = map_int(arg2[j], NULL);
 				end = map_int(sep + 1, NULL);
-				if (st <= 0 || end <= 0 || st > MAX_ADAPTERS || end > MAX_ADAPTERS || end < st)
+				if (st < 0 || end < 0 || st >= MAX_ADAPTERS || end >= MAX_ADAPTERS || end < st)
 					goto ERR;
 				for (k = st; k <= end; k++)
 				{
 					adap = k;
-					source_map[i] |= (unsigned long)1 << (adap - 1);
+					source_map[i] |= (unsigned long)1 << adap;
 				}
 			}
 		}
 		buf2[0]='\0';
-		for (j = 1; j <= (la > MAX_ADAPTERS ? MAX_ADAPTERS : la); j++)
-			if (source_map[i] & ((unsigned long)1 << (j - 1)))
+		for (j = 0; j < MAX_ADAPTERS; j++)
+			if (source_map[i] & ((unsigned long)1 << j))
 				strcat(buf2, "X");
 			else
 				strcat(buf2, ".");

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -96,12 +96,12 @@ adapter *adapter_alloc()
 	ad->master_source = -1;
 	ad->diseqc_multi = opts.diseqc_multi;
 
-    /* enable sources */
-    int i;
-    for (i = 0; i <= MAX_SOURCES; i++)
-    {
-            ad->sources_pos[i] = 1;
-    }
+	/* enable sources */
+	int i;
+	for (i = 0; i <= MAX_SOURCES; i++)
+	{
+		ad->sources_pos[i] = 1;
+	}
 
 	/* LOF setup */
 	ad->diseqc_param.lnb_low = opts.lnb_low;
@@ -509,13 +509,11 @@ int getAdaptersCount()
 	for (i = 0; i < MAX_ADAPTERS; i++)
 		if ((ad = a[i]))
 		{
-                       // Note: Adapter 1 uses bit 0, and source_map uses ranges from 0..SRC-1
-                       if (i > 0) for (j = 1; j <= MAX_SOURCES; j++)
-                       {
-//                             ad->sources_pos[j] = (source_map[j] >> i) & 1;
-                               ad->sources_pos[j] = (source_map[j-1] >> (i - 1)) & 1;
-//                             ad->sources_pos[j] = 0;
-                       }
+			// Note: Adapter 1 uses bit 0, and source_map uses ranges from 0..SRC-1
+			if (i > 0) for (j = 1; j <= MAX_SOURCES; j++)
+			{
+				ad->sources_pos[j] = (source_map[j-1] >> (i - 1)) & 1;
+			}
 
 			if (!opts.force_sadapter && (delsys_match(ad, SYS_DVBS) || delsys_match(ad, SYS_DVBS2)))
 			{
@@ -584,16 +582,24 @@ int getAdaptersCount()
 			}
 		}
 	}
-    DEBUGM("Current sources assignment: ");
-    for (i = 0; i < MAX_ADAPTERS; i++)
-            if ((ad = a[i]))
-            {
-                    for (j = 1; j <= MAX_SOURCES; j++)
-                    {
-                            if (ad->sources_pos[j])
-                                    DEBUGM("  Adpater %d enabled SRC=%d", i, j);
-                    }
-            }
+	char lsrc[256];
+	for (i = 0; i < MAX_ADAPTERS; i++)
+		if ((ad = a[i]))
+		{
+			lsrc[0] = '\0';
+			for (j = 1; j <= MAX_SOURCES; j++)
+			{
+				if (ad->sources_pos[j])
+				{
+					char usrc[8];
+					sprintf(usrc, ",%d", j);
+					strcat(lsrc, usrc);
+				}
+			}
+			if (strlen(lsrc) > 0)
+				lsrc[0]=' ';
+			DEBUGM("Adpater %d enabled sources:%s", i, lsrc);
+		}
 	return tuner_s2 + tuner_c2 + tuner_t2 + tuner_c + tuner_t;
 }
 

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -742,8 +742,7 @@ int get_free_adapter(transponder *tp)
 				match = 1;
 			if (!ad->enabled || !compare_tunning_parameters(ad->id, tp))
 				match = 1;
-			//if (match && !init_hw(fe))
-            if (match && ad->sources_pos[tp->diseqc] && !init_hw(fe))
+			if (match && ad->sources_pos[tp->diseqc] && !init_hw(fe))
 				return fe;
 		}
 		goto noadapter;
@@ -757,12 +756,10 @@ int get_free_adapter(transponder *tp)
 	for (i = 0; i < MAX_ADAPTERS; i++)
 	{
 		//first free adapter that has the same msys
-		//if ((ad = get_adapter_nw(i)) && ad->sid_cnt == 0 && delsys_match(ad, msys) && !compare_slave_parameters(ad, tp))
 		if ((ad = get_adapter_nw(i)) && ad->sid_cnt == 0 && delsys_match(ad, msys) && !compare_slave_parameters(ad, tp) && ad->sources_pos[tp->diseqc])
 			return i;
 		if (!ad && delsys_match(a[i], msys) && !compare_slave_parameters(a[i], tp)) // device is not initialized
 		{
-			//if (!init_hw(i))
 			ad = a[i];
 			if (ad->sources_pos[tp->diseqc] && !init_hw(i))
 				return i;
@@ -770,7 +767,6 @@ int get_free_adapter(transponder *tp)
 	}
 
 noadapter:
-	//LOG("no adapter found for f:%d pol:%d msys:%d", tp->freq, tp->pol, tp->sys);
 	LOG("no adapter found for src:%d f:%d pol:%d msys:%d", tp->diseqc, tp->freq, tp->pol, tp->sys);
 	dump_adapters();
 	return -1;

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -96,7 +96,9 @@ adapter *adapter_alloc()
 	ad->master_source = -1;
 	ad->diseqc_multi = opts.diseqc_multi;
 
-	/* enable sources */
+	/* enable all sources */
+	ad->debug_pos[0]='\0';
+	ad->debug_src = 0;
 	int i;
 	for (i = 0; i <= MAX_SOURCES; i++)
 	{
@@ -586,6 +588,8 @@ int getAdaptersCount()
 	for (i = 0; i < MAX_ADAPTERS; i++)
 		if ((ad = a[i]))
 		{
+			ad->debug_pos[0]='\0';
+			ad->debug_src = 0;
 			lsrc[0] = '\0';
 			for (j = 1; j <= MAX_SOURCES; j++)
 			{
@@ -594,11 +598,19 @@ int getAdaptersCount()
 					char usrc[8];
 					sprintf(usrc, ",%d", j);
 					strcat(lsrc, usrc);
+
+					strcat(ad->debug_pos, "X");
+					ad->debug_src += (unsigned long)1 << (j - 1);
+				}
+				else
+				{
+					strcat(ad->debug_pos, ".");
 				}
 			}
 			if (strlen(lsrc) > 0)
 				lsrc[0]=' ';
 			DEBUGM("Adpater %d enabled sources:%s", i, lsrc);
+			DEBUGM("Adpater %d debug sources: %s (%lu)", i, ad->debug_pos, ad->debug_src);
 		}
 	return tuner_s2 + tuner_c2 + tuner_t2 + tuner_c + tuner_t;
 }
@@ -612,10 +624,10 @@ void dump_adapters()
 	LOG("Dumping adapters:");
 	for (i = 0; i < MAX_ADAPTERS; i++)
 		if ((ad = get_adapter_nw(i)))
-			LOG("%d|f: %d sid_cnt:%d master_sid:%d master_source:%d del_sys: %s %s %s", i,
+			LOG("%d|f: %d sid_cnt:%d master_sid:%d master_source:%d del_sys: %s,%s,%s src_map: %s (%lu)", i,
 				ad->tp.freq, ad->sid_cnt, ad->master_sid, ad->master_source,
 				get_delsys(ad->sys[0]), get_delsys(ad->sys[1]),
-				get_delsys(ad->sys[2]));
+				get_delsys(ad->sys[2]), ad->debug_pos, ad->debug_src);
 	dump_streams();
 }
 

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -6,6 +6,7 @@
 typedef struct ca_device ca_device_t;
 
 #define MAX_ADAPTERS 32
+#define MAX_SOURCES 64
 #define DVR_BUFFER 30 * 1024 * 188
 
 #define ADAPTER_BUFFER 384 * DVB_FRAME // 128 * 3 > 65535
@@ -71,6 +72,7 @@ typedef struct struct_adapter
 	uint32_t pid_err, dec_err;				   // detect pids received but not part of any stream, decrypt errors
 	diseqc diseqc_param;
 	int diseqc_multi;
+    int sources_pos[MAX_SOURCES + 1];
 	int old_diseqc;
 	int old_hiband;
 	int old_pol;
@@ -110,6 +112,7 @@ typedef struct struct_adapter
 } adapter;
 
 extern adapter *a[MAX_ADAPTERS];
+uint64_t source_map[MAX_SOURCES];
 extern int a_count;
 extern char do_dump_pids;
 
@@ -137,6 +140,7 @@ void dump_pids(int aid);
 void sort_pids(int aid);
 void enable_adapters(char *o);
 void set_unicable_adapters(char *o, int type);
+void set_sources_adapters(char *o);
 void set_diseqc_adapters(char *o);
 void set_diseqc_timing(char *o);
 void set_diseqc_multi(char *o);

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -72,7 +72,9 @@ typedef struct struct_adapter
 	uint32_t pid_err, dec_err;				   // detect pids received but not part of any stream, decrypt errors
 	diseqc diseqc_param;
 	int diseqc_multi;
-	int sources_pos[MAX_SOURCES + 1];
+	int sources_pos[MAX_SOURCES + 1]; // includes SRC=0 used internally only
+	char debug_pos[MAX_SOURCES + 1];
+	uint64_t debug_src;
 	int old_diseqc;
 	int old_hiband;
 	int old_pol;

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -72,7 +72,7 @@ typedef struct struct_adapter
 	uint32_t pid_err, dec_err;				   // detect pids received but not part of any stream, decrypt errors
 	diseqc diseqc_param;
 	int diseqc_multi;
-    int sources_pos[MAX_SOURCES + 1];
+	int sources_pos[MAX_SOURCES + 1];
 	int old_diseqc;
 	int old_hiband;
 	int old_pol;

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -87,6 +87,7 @@ int rtsp, http, si, si1, ssdp1;
 #define ENABLE_ADAPTERS_OPT 'e'
 #define UNICABLE_OPT 'u'
 #define JESS_OPT 'j'
+#define SOURCES_OPT 'U'
 #define DISEQC_OPT 'd'
 #define DISEQC_TIMING_OPT 'q'
 #define SLAVE_OPT 'S'
@@ -136,6 +137,7 @@ static const struct option long_options[] =
 		{"enable-adapters", required_argument, NULL, 'e'},
 		{"unicable", required_argument, NULL, 'u'},
 		{"jess", required_argument, NULL, 'j'},
+        {"sources", required_argument, NULL, 'U'},
 		{"diseqc", required_argument, NULL, 'd'},
 		{"diseqc-timing", required_argument, NULL, 'q'},
 		{"diseqc-multi", required_argument, NULL, DISEQC_MULTI},
@@ -460,6 +462,13 @@ Help\n\
 \n\
 * -j --jess jess_string - same format as -u \n\
 \n\
+* -U --sources sources_for_adapters: select the adapters for each source\n\
+       * eg: -U 0-2:*:3:1,5,7 (no spaces between parameters)\n\
+       - In this example: for SRC=1 only 0,1,2; for SRC=2 all: for SRC=3 only 3; and for SRC=4 the 1,5,7 adapters.\n\
+       - For each position (separated by : ) you need to declare all the adapters that use this position\n\
+       - The special char * indicates all adapters for this position\n\
+       - If errors or by default all adapters have enabled all positions\n\
+\n\
 * -w --http-host http_server[:port]: specify the host and the port (if not 80) where the xml file can be downloaded from [default: default_local_ip_address:8080] \n\
 	* eg: -w 192.168.1.1:8080 \n\
 \n\
@@ -526,6 +535,7 @@ void set_options(int argc, char *argv[])
 {
 	int opt;
 	int is_log = 0;
+    int adapter_sources = 0;
 	char *lip;
 	memset(&opts, 0, sizeof(opts));
 	opts.log = 1;
@@ -599,7 +609,7 @@ void set_options(int argc, char *argv[])
 
 #endif
 
-	while ((opt = getopt_long(argc, argv, "fl:v:r:a:td:w:p:s:n:hB:b:H:m:p:e:x:u:j:o:gy:i:q:D:NGVR:S:TX:Y:OL:EP:Z:0:F:M:1:2:3:C:4" AXE_OPTS, long_options, NULL)) != -1)
+	while ((opt = getopt_long(argc, argv, "fl:v:r:a:td:w:p:s:n:hB:b:H:m:p:e:x:u:j:U:o:gy:i:q:D:NGVR:S:TX:Y:OL:EP:Z:0:F:M:1:2:3:C:4" AXE_OPTS, long_options, NULL)) != -1)
 	{
 		//              printf("options %d %c %s\n",opt,opt,optarg);
 		switch (opt)
@@ -812,6 +822,13 @@ void set_options(int argc, char *argv[])
 			set_diseqc_adapters(optarg);
 			break;
 		}
+
+        case SOURCES_OPT:
+        {
+                adapter_sources = 1;
+                set_sources_adapters(optarg);
+                break;
+        }
 
 		case DISEQC_TIMING_OPT:
 		{
@@ -1031,6 +1048,8 @@ void set_options(int argc, char *argv[])
 	}
 	if (!is_log)
 		opts.log = 0;
+    if (!adapter_sources)
+            set_sources_adapters("");
 
 	// FBC setup
 	if (!access("/proc/stb/frontend/0/fbc_connect", W_OK))

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -137,7 +137,7 @@ static const struct option long_options[] =
 		{"enable-adapters", required_argument, NULL, 'e'},
 		{"unicable", required_argument, NULL, 'u'},
 		{"jess", required_argument, NULL, 'j'},
-        {"sources", required_argument, NULL, 'U'},
+		{"sources", required_argument, NULL, 'U'},
 		{"diseqc", required_argument, NULL, 'd'},
 		{"diseqc-timing", required_argument, NULL, 'q'},
 		{"diseqc-multi", required_argument, NULL, DISEQC_MULTI},
@@ -823,12 +823,12 @@ void set_options(int argc, char *argv[])
 			break;
 		}
 
-        case SOURCES_OPT:
-        {
-                adapter_sources = 1;
-                set_sources_adapters(optarg);
-                break;
-        }
+		case SOURCES_OPT:
+		{
+			adapter_sources = 1;
+			set_sources_adapters(optarg);
+			break;
+		}
 
 		case DISEQC_TIMING_OPT:
 		{
@@ -1048,8 +1048,8 @@ void set_options(int argc, char *argv[])
 	}
 	if (!is_log)
 		opts.log = 0;
-    if (!adapter_sources)
-            set_sources_adapters("");
+	if (!adapter_sources)
+		set_sources_adapters("");
 
 	// FBC setup
 	if (!access("/proc/stb/frontend/0/fbc_connect", W_OK))

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -462,12 +462,13 @@ Help\n\
 \n\
 * -j --jess jess_string - same format as -u \n\
 \n\
-* -U --sources sources_for_adapters: select the adapters for each source\n\
-       * eg: -U 0-2:*:3:1,5,7 (no spaces between parameters)\n\
-       - In this example: for SRC=1 only 0,1,2; for SRC=2 all: for SRC=3 only 3; and for SRC=4 the 1,5,7 adapters.\n\
-       - For each position (separated by : ) you need to declare all the adapters that use this position\n\
-       - The special char * indicates all adapters for this position\n\
-       - If errors or by default all adapters have enabled all positions\n\
+* -U --sources sources_for_adapters: limit the adapters to specific sources/positions\n\
+	* eg: -U 0-2:*:3:2,6,8 (no spaces between parameters)\n\
+	- In this example: for SRC=1 only 0,1,2; for SRC=2 all: for SRC=3 only 3; and for SRC=4 the 2,6,8 adapters are used.\n\
+	- For each position (separated by : ) you need to declare all the adapters that use this position with no exception.\n\
+	- The special char * indicates all adapters for this position.\n\
+	- The number of sources range from 1 to 64; but the list can include less than 64 (in this case all are enabled for undefined sources).\n\
+	- By default or in case of errors all adapters have enabled all positions.\n\
 \n\
 * -w --http-host http_server[:port]: specify the host and the port (if not 80) where the xml file can be downloaded from [default: default_local_ip_address:8080] \n\
 	* eg: -w 192.168.1.1:8080 \n\


### PR DESCRIPTION
This patch adds a new parameter (-U) to limit specific sources to some adapters.

It supersedes previous #623 with these changes:
- More robust functionality.
- Increased total number of sources to 64.
- The list of the sources parameter can be less than the MAX_SOURCES.
- Improved debug to identify troubles.
