### PR TITLE
LOG improvement

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -212,7 +212,7 @@ int close_adapter_for_socket(sockets *s)
 {
 	int aid = s->sid;
 	adapter *ad = get_adapter(aid);
-	LOG("closing DVR socket %d pos %d aid %d", s->sock, s->id, aid);
+	LOG("closing DVR socket sock %d (handle %d) adapter %d", s->sock, s->id, aid);
 	if (ad && (s->sid == ad->sock))
 	{
 		ad->sock = -1;

--- a/src/csa.c
+++ b/src/csa.c
@@ -47,6 +47,8 @@
 #include "pmt.h"
 #include <dvbcsa/dvbcsa.h>
 
+#define DEFAULT_LOG LOG_DVBCA
+
 void dvbcsa_create_key(SCW *cw)
 {
 	cw->key = dvbcsa_bs_key_alloc();

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -57,7 +57,7 @@
 
 struct struct_opts opts;
 
-#define DEFAULT_LOG LOG_HTTP
+#define DEFAULT_LOG LOG_GENERAL
 
 #define DESC_XML "desc.xml"
 #define PID_NAME "/var/run/%s.pid"
@@ -1060,6 +1060,9 @@ void set_options(int argc, char *argv[])
 		set_slave_adapters("2-7:0");
 }
 
+#undef DEFAULT_LOG
+#define DEFAULT_LOG LOG_RTSP
+
 #define RBUF 32000
 
 int read_rtsp(sockets *s)
@@ -1068,9 +1071,13 @@ int read_rtsp(sockets *s)
 	int cseq, la, i, rlen;
 	char *transport = NULL, *useragent = NULL;
 	int sess_id = 0;
+	int log_level = LOG_RTSP;
 	char buf[2000];
 	char ra[50];
 	streams *sid = get_sid(s->sid);
+
+	if (s->type == TYPE_HTTP)
+		log_level = LOG_HTTP;
 
 	if (s->rlen > 3 && s->buf[0] == 0x24 && s->buf[1] < 2)
 	{
@@ -1078,9 +1085,8 @@ int read_rtsp(sockets *s)
 			sid->rtime = s->rtime;
 
 		int rtsp_len = s->buf[2] * 256 + s->buf[3];
-		LOG(
-			"Received RTSP over tcp packet (sock_id %d) sid %d, rlen %d, packet len: %d, type %02X %02X discarding %s...",
-			s->id, s->sid, s->rlen, rtsp_len, s->buf[4], s->buf[5],
+		LOG("Received %s over tcp packet (sock_id %d) sid %d, rlen %d, packet len: %d, type %02X %02X discarding %s...",
+			s->type == 3 ? "HTTP" : "RTSP" , s->id, s->sid, s->rlen, rtsp_len, s->buf[4], s->buf[5],
 			(s->rlen == rtsp_len + 4) ? "complete" : "fragment");
 		if (s->rlen >= rtsp_len + 4)
 		{ // we did not receive the entire packet
@@ -1103,13 +1109,11 @@ int read_rtsp(sockets *s)
 	{
 		if (s->rlen > RBUF - 10)
 		{
-			LOG(
-				"Discarding %d bytes from the socket buffer, request > %d, consider increasing  RBUF",
+			LOG("read_rtsp: Discarding %d bytes from the socket buffer, request > %d, consider increasing  RBUF",
 				s->rlen, RBUF);
 			s->rlen = 0;
 		}
-		LOG(
-			"read_rtsp: read %d bytes from handle %d, sock_id %d, flags %d not ending with \\r\\n\\r\\n",
+		LOG("read_rtsp: read %d bytes from handle %d, sock_id %d, flags %d not ending with \\r\\n\\r\\n",
 			s->rlen, s->sock, s->id, s->flags);
 		hexdump("read_rtsp: ", s->buf, s->rlen);
 		if (s->flags & 1)
@@ -1124,10 +1128,10 @@ int read_rtsp(sockets *s)
 	rlen = s->rlen;
 	s->rlen = 0;
 
-	LOG("Read RTSP (handle %d) [%s:%d] sid %d, len: %d, sock %d", s->sid,
-		get_sockaddr_host(s->sa, ra, sizeof(ra)), get_sockaddr_port(s->sa),
-		s->id, rlen, s->sock);
-	LOGM("MSG client >> process :\n%s", s->buf);
+	LOG("Read %s (sid %d) [%s:%d] len: %d sock %d (handle %d)", s->type == 3 ? "HTTP" : "RTSP" ,
+		s->sid, get_sockaddr_host(s->sa, ra, sizeof(ra)), get_sockaddr_port(s->sa),
+		rlen, s->id, s->sock);
+	LOGL(log_level, "MSG client >> process :\n%s", s->buf);
 
 	if ((s->type != TYPE_HTTP) && (strncasecmp((const char *)s->buf, "GET", 3) == 0))
 	{
@@ -1162,7 +1166,7 @@ int read_rtsp(sockets *s)
 	sid = get_sid(s->sid);
 	if (sid)
 	{
-		LOGM("Updating sid %d time to %jd, current time %jd", sid->sid, s->rtime, getTick());
+		LOGL(log_level, "Updating sid %d time to %jd, current time %jd", sid->sid, s->rtime, getTick());
 		sid->rtime = s->rtime;
 	}
 
@@ -1308,6 +1312,9 @@ int read_rtsp(sockets *s)
 	return 0;
 }
 
+#undef DEFAULT_LOG
+#define DEFAULT_LOG LOG_HTTP
+
 #define REPLY_AND_RETURN(c)                    \
 	{                                          \
 		http_response(s, c, NULL, NULL, 0, 0); \
@@ -1326,6 +1333,7 @@ int read_http(sockets *s)
 	char buf[2000]; // the XML should not be larger than 1400 as it will create problems
 	char url[300];
 	char ra[50];
+	int log_level = LOG_RTSP;
 	char *space;
 	int is_head = 0;
 	static char *xml =
@@ -1347,12 +1355,13 @@ int read_http(sockets *s)
 		"<satip:X_SATIPCAP xmlns:satip=\"urn:ses-com:satip\">%s</satip:X_SATIPCAP>"
 		"%s"
 		"</device></root>";
+	if (s->type == TYPE_HTTP)
+		log_level = LOG_HTTP;
 	if (s->rlen < 5 || !end_of_header((char *)s->buf + s->rlen - 4))
 	{
 		if (s->rlen > RBUF - 10)
 		{
-			LOG(
-				"Discarding %d bytes from the socket buffer, request > %d, consider increasing  RBUF",
+			LOG("read_http: Discarding %d bytes from the socket buffer, request > %d, consider increasing  RBUF",
 				s->rlen, RBUF);
 			s->rlen = 0;
 		}
@@ -1415,10 +1424,10 @@ int read_http(sockets *s)
 	int secs = seconds;
 	sprintf(opts.time_running, "%.0d%s%02d:%02d:%02d", days, days > 0 ? "d " : "", hours, mins, secs);
 
-	LOG("Read HTTP (handle %d) [%s:%d] sid %d, sock %d", s->sid,
+	LOG("Read %s (sid %d) [%s:%d] sock %d (handle %d)", s->type == 3 ? "HTTP" : "RTSP", s->sid,
 		get_sockaddr_host(s->sa, ra, sizeof(ra)), get_sockaddr_port(s->sa),
-		s->sid, s->sock);
-	LOGM("MSG client >> process :\n%s", s->buf);
+		s->id, s->sock);
+	LOGL(log_level, "MSG client >> process :\n%s", s->buf);
 
 	split(arg, (char *)s->buf, ARRAY_SIZE(arg), ' ');
 	//      LOG("args: %s -> %s -> %s",arg[0],arg[1],arg[2]);
@@ -1519,13 +1528,15 @@ int read_http(sockets *s)
 
 int close_http(sockets *s)
 {
+	char ra[50];
 	streams *sid = get_sid(s->sid);
 	if ((s->flags & 1) && s->buf)
 		free1(s->buf);
 	s->flags = 0;
 	s->buf = NULL;
-	LOG("Requested sid close %d timeout %d type %d", s->sid,
-		sid ? sid->timeout : -1, sid ? sid->type : -1);
+	LOG("Requested %s close (sid %d) [%s:%d] timeout %d type %d sock %d (handle %d)", s->type == 3 ? "HTTP" : "RTSP",
+		s->sid, get_sockaddr_host(s->sa, ra, sizeof(ra)), get_sockaddr_port(s->sa),
+		sid ? sid->timeout : -1, sid ? sid->type : -1, s->id, s->sock);
 	if (sid && ((sid->type == STREAM_RTSP_UDP && sid->timeout != 0) || (sid->type == 0 && sid->timeout != 0)))
 		// Do not close rtsp udp as most likely there was no TEARDOWN at this point
 		return 0;
@@ -1708,7 +1719,7 @@ int ssdp_reply(sockets *s)
 }
 
 #undef DEFAULT_LOG
-#define DEFAULT_LOG LOG_HTTP
+#define DEFAULT_LOG LOG_RTSP
 
 int new_rtsp(sockets *s)
 {
@@ -1720,6 +1731,9 @@ int new_rtsp(sockets *s)
 	return 0;
 }
 
+#undef DEFAULT_LOG
+#define DEFAULT_LOG LOG_HTTP
+
 int new_http(sockets *s)
 {
 	s->type = TYPE_HTTP;
@@ -1729,6 +1743,9 @@ int new_http(sockets *s)
 		s->nonblock = 1;
 	return 0;
 }
+
+#undef DEFAULT_LOG
+#define DEFAULT_LOG LOG_GENERAL
 
 void write_pid_file()
 {
@@ -1749,6 +1766,9 @@ extern int sock_signal;
 int main(int argc, char *argv[])
 {
 	int sock_bw, rv, devices;
+	int i;
+	unsigned long log_it;
+	USockAddr sv;
 	main_tid = get_tid();
 	strcpy(thread_name, "main");
 	set_options(argc, argv);
@@ -1766,6 +1786,13 @@ int main(int argc, char *argv[])
 
 	print_version(1);
 
+	for (i = 1; i <= 18; i++)
+	{
+		log_it = (1UL << i);
+		LOGL(log_it,   " LOG  of the module enabled: %s", loglevels[i]);
+		DEBUGL(log_it, "DEBUG of the module enabled: %s", loglevels[i]);
+	}
+
 	readBootID();
 	if ((rtsp = tcp_listen(NULL, opts.rtsp_port, opts.use_ipv4_only)) < 1)
 		FAIL("RTSP: Could not listen on port %d", opts.rtsp_port);
@@ -1778,9 +1805,10 @@ int main(int argc, char *argv[])
 		if ((ssdp1 = udp_bind(opts.disc_host, 1900, 1)) < 1)
 			FAIL("SSDP: Could not bind on %s udp port 1900", opts.disc_host);
 
-		si = sockets_add(ssdp, NULL, -1, TYPE_UDP, (socket_action)ssdp_reply,
+		fill_sockaddr(&sv, "0.0.0.0", 1900, 1);
+		si = sockets_add(ssdp, &sv, -1, TYPE_UDP, (socket_action)ssdp_reply,
 						 (socket_action)ssdp_byebye, (socket_action)ssdp_discovery);
-		si1 = sockets_add(ssdp1, NULL, -1, TYPE_UDP, (socket_action)ssdp_reply,
+		si1 = sockets_add(ssdp1, &sv, -1, TYPE_UDP, (socket_action)ssdp_reply,
 						  (socket_action)ssdp_byebye, (socket_action)ssdp_discovery);
 		if (si < 0 || si1 < 0)
 			FAIL("sockets_add failed for ssdp");
@@ -1788,10 +1816,12 @@ int main(int argc, char *argv[])
 
 	sockets_timeout(si, 60 * 1000);
 	set_sockets_rtime(si, -60 * 1000);
-	if (0 > sockets_add(rtsp, NULL, -1, TYPE_SERVER, (socket_action)new_rtsp,
+	fill_sockaddr(&sv, "0.0.0.0", opts.rtsp_port, 1);
+	if (0 > sockets_add(rtsp, &sv, -1, TYPE_SERVER, (socket_action)new_rtsp,
 						NULL, (socket_action)close_http))
 		FAIL("sockets_add failed for rtsp");
-	if (0 > sockets_add(http, NULL, -1, TYPE_SERVER, (socket_action)new_http,
+	fill_sockaddr(&sv, "0.0.0.0", opts.http_port, 1);
+	if (0 > sockets_add(http, &sv, -1, TYPE_SERVER, (socket_action)new_http,
 						NULL, (socket_action)close_http))
 		FAIL("sockets_add failed for http");
 
@@ -1874,6 +1904,9 @@ int readBootID()
 	return opts.bootid;
 }
 
+#undef DEFAULT_LOG
+#define DEFAULT_LOG LOG_HTTP
+
 void http_response(sockets *s, int rc, char *ah, char *desc, int cseq, int lr)
 {
 	int binary = 0;
@@ -1945,11 +1978,14 @@ void http_response(sockets *s, int rc, char *ah, char *desc, int cseq, int lr)
 	else
 		strlcatf(resp, sizeof(resp) - 1, lresp, "\r\n");
 
-	LOG("Reply %s(handle %d) [%s:%d] content_len:%d, sock %d",
-		(lresp == sizeof(resp) - 1) ? "(message truncated) " : "", s->sock,
+	LOG("Reply %s %s(sid %d) [%s:%d] content_len:%d, sock %d (handle %d)", s->type == 3 ? "HTTP" : "RTSP" ,
+		(lresp == sizeof(resp) - 1) ? "(message truncated) " : "", s->sid,
 		get_sockaddr_host(s->sa, ra, sizeof(ra)), get_sockaddr_port(s->sa),
-		lr, s->id);
-	LOGM("MSG client << process :\n%s", resp);
+		lr, s->id, s->sock);
+	int log_level = LOG_RTSP;
+	if (s->type == TYPE_HTTP)
+		log_level = LOG_HTTP;
+	LOGL(log_level,"MSG client << process :\n%s", resp);
 
 	struct iovec iov[2];
 	iov[0].iov_base = resp;

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -401,13 +401,14 @@ int satipc_open_device(adapter *ad)
 	if ((sip->last_connect > 0) && (ctime - sip->last_connect < 5000))
 		return 3;
 
+	USockAddr sv;
 	sip->last_connect = ctime;
-	ad->fe = tcp_connect_src(sip->sip, sip->sport, NULL, 1, sip->source_ip[0] ? sip->source_ip : NULL); // blocking socket
+	ad->fe = tcp_connect_src(sip->sip, sip->sport, &sv, 1, sip->source_ip[0] ? sip->source_ip : NULL); // blocking socket
 	if (ad->fe < 0)
 		LOG_AND_RETURN(2, "could not connect to %s:%d", sip->sip, sip->sport);
 
-	LOG("satipc: connected to SAT>IP server %s port %d %s handle %d %s %s", sip->sip,
-		sip->sport, sip->use_tcp ? "[RTSP OVER TCP]" : "", ad->fe, sip->source_ip[0] ? "from source" : "", sip->source_ip[0] ? sip->source_ip : "");
+	LOG("satipc: connected to SAT>IP server %s port %d%s (socket handle %d) %s %s", sip->sip,
+		sip->sport, sip->use_tcp ? " [RTSP OVER TCP]" : "", ad->fe, sip->source_ip[0] ? "from source" : "", sip->source_ip[0] ? sip->source_ip : "");
 
 	sip->init_use_tcp = sip->use_tcp;
 	if (!sip->init_use_tcp)
@@ -421,12 +422,12 @@ int satipc_open_device(adapter *ad)
 		if (sip->rtcp < 0)
 			LOG("Could not listen on port %d: err %d: %s", sip->listen_rtp + 1, errno, strerror(errno));
 
-		ad->fe_sock = sockets_add(ad->fe, NULL, ad->id, TYPE_TCP,
+		ad->fe_sock = sockets_add(ad->fe, &sv, ad->id, TYPE_TCP,
 								  (socket_action)satipc_reply, (socket_action)satipc_close,
 								  (socket_action)satipc_timeout);
 		sip->rtcp_sock = -1;
 		if (sip->rtcp >= 0)
-			sip->rtcp_sock = sockets_add(sip->rtcp, NULL, ad->id, TYPE_TCP,
+			sip->rtcp_sock = sockets_add(sip->rtcp, &sv, ad->id, TYPE_TCP,
 										 (socket_action)satipc_rtcp_reply, (socket_action)satipc_close,
 										 NULL);
 		sockets_timeout(ad->fe_sock, 25000); // 25s
@@ -451,7 +452,7 @@ int satipc_open_device(adapter *ad)
 	{
 		ad->dvr = ad->fe;
 		ad->fe = -1;
-		ad->fe_sock = sockets_add(SOCK_TIMEOUT, NULL, ad->id, TYPE_UDP,
+		ad->fe_sock = sockets_add(SOCK_TIMEOUT, &sv, ad->id, TYPE_UDP,
 								  NULL, NULL, (socket_action)satipc_timeout);
 		sockets_timeout(ad->fe_sock, 25000); // 25s
 	}

--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -207,7 +207,7 @@ int udp_bind(char *addr, int port, int ipv4_only)
 
 	set_linux_socket_timeout(sock);
 
-	LOG("New UDP socket %d bound to %s:%d %s%s%s", sock, get_sockaddr_host(serv, localhost, sizeof(localhost)),
+	LOG("New UDP bound socket %d at %s:%d %s%s%s", sock, get_sockaddr_host(serv, localhost, sizeof(localhost)),
 		get_sockaddr_port(serv), is_multicast ? "(mcast:" : "", is_multicast ? addr : "", is_multicast ? ")" : "");
 	return sock;
 }
@@ -265,7 +265,7 @@ int udp_connect(char *addr, int port, USockAddr *serv)
 		close(sock);
 		return -1;
 	}
-	LOG("New UDP socket %d connected to %s:%d", sock,
+	LOG("New UDP connected socket %d to %s:%d", sock,
 		get_sockaddr_host(*serv, localhost, sizeof(localhost)), get_sockaddr_port(*serv));
 	return sock;
 }
@@ -416,7 +416,7 @@ int tcp_listen(char *addr, int port, int ipv4_only)
 		close(sock);
 		return -1;
 	}
-	LOG("New TCP listening socket %d at %s:%d, family %d", sock, addr ? addr : "0:0:0:0", port, family);
+	LOG("New TCP listening socket %d at %s:%d, family %d", sock, get_sockaddr_host(serv, sa, sizeof(sa)), port, family);
 	return sock;
 }
 
@@ -565,6 +565,7 @@ int sockets_add(int sock, USockAddr *sa, int sid, int type,
 	int i;
 	char ra[50];
 	sockets *ss;
+	int lport = (sa && sa->lport > 0 && !(sa->sa.sa_data)) ? sa->lport : 0;
 
 	if (sock < 0 && sock != SOCK_TIMEOUT)
 		LOG_AND_RETURN(-1, "sockets_add does not add negative sockets %d", sock);
@@ -623,9 +624,11 @@ int sockets_add(int sock, USockAddr *sa, int sid, int type,
 	if (type & TYPE_CONNECT)
 		ss->events |= POLLOUT;
 
-	LOG("sockets_add: handle %d (type %d) returning socket sock %d [%s:%d] read: %p",
-		ss->sock, ss->type, i, get_sockaddr_host(ss->sa, ra, sizeof(ra)),
-		get_sockaddr_port(ss->sa), ss->read);
+	LOG("sockets_add: returning socket sock %d (handle %d) (type %d) [%s:%d]",
+		ss->sock, i, ss->type, get_sockaddr_host(ss->sa, ra, sizeof(ra)),
+		get_sockaddr_port(ss->sa) > 0 ? get_sockaddr_port(ss->sa) : -1);
+	LOGM("new socket sock %d (handle %d) -> read(): %p action(): %p close(): %p timeout(): %p",
+		ss->sock, i, ss->read, ss->action, ss->close, ss->timeout);
 	mutex_unlock(&ss->mutex);
 	return i;
 }
@@ -633,6 +636,7 @@ int sockets_add(int sock, USockAddr *sa, int sid, int type,
 int sockets_del(int sock)
 {
 	int i, so;
+	char ra[50];
 	sockets *ss;
 
 	if (sock < 0 || sock >= MAX_SOCKS || !s[sock] || !s[sock]->enabled || !s[sock]->is_enabled)
@@ -651,8 +655,11 @@ int sockets_del(int sock)
 	ss->is_enabled = 0;
 	so = ss->sock;
 	ss->sock = -1; // avoid infinite loop
-	LOG("sockets_del: sock %d -> handle %d, sid %d, overflow bytes %d, allocated %d, used %d, unsend packets %d",
-		sock, so, ss->sid, ss->overflow, ss->buf_alloc, ss->buf_used, (ss->wmax > 0) ? ((ss->wpos - ss->spos) % ss->wmax) : 0);
+	LOG("sockets_del: deleting socket sock %d (handle %d) [%s:%d], sid %d, overflow bytes %d, allocated %d, used %d, unsend packets %d",
+		sock, so, get_sockaddr_host(ss->sa, ra, sizeof(ra)),
+		get_sockaddr_port(ss->sa) > 0 ? get_sockaddr_port(ss->sa) : -1, ss->sid,
+		ss->overflow, ss->buf_alloc, ss->buf_used,
+		(ss->wmax > 0) ? ((ss->wpos - ss->spos) % ss->wmax) : 0);
 
 	if (so >= 0)
 	{
@@ -685,7 +692,7 @@ int sockets_del(int sock)
 		ss->pack = NULL;
 	}
 
-	LOG("sockets_del: sock %d Last open socket is at index %d current_handle %d",
+	LOGM("sockets_del: sock %d Last open socket is at index %d current_handle %d",
 		sock, i, so);
 	mutex_destroy(&ss->mutex);
 	mutex_lock(&s_mutex);
@@ -741,7 +748,7 @@ void *select_and_execute(void *arg)
 	es = 0;
 	lt = getTick();
 	memset(&pf, -1, sizeof(pf));
-	LOG("Starting select_and_execute on thread ID %lx, thread_name %s", tid,
+	LOG("Starting select_and_execute on thread ID %lx, thread_name [%s]", tid,
 		thread_name);
 	while (run_loop)
 	{
@@ -916,7 +923,7 @@ void *select_and_execute(void *arg)
 							continue; // do not close the RTCP socket, we might get some errors here but ignore them
 						}
 						LOG(
-							"select_and_execute[%d]: %s on socket %d (sid:%d) from %s:%d - type %s errno %d",
+							"select_and_execute[%d]: %s on socket sock %d (sid %d) from %s:%d - type %s errno %d",
 							i, err_str, ss->sock, ss->sid,
 							get_sockaddr_host(ss->sa, ra, sizeof(ra)),
 							get_sockaddr_port(ss->sa), types[ss->type], err);
@@ -1272,7 +1279,7 @@ void set_socket_thread(int s_id, pthread_t tid)
 	sockets *ss = get_sockets(s_id);
 	if (!ss)
 		return;
-	LOG("set_socket_thread: thread %lx for sockets %i", tid, s_id);
+	LOG("set_socket_thread: thread %lx for socket handle %i", tid, s_id);
 	ss->tid = tid;
 }
 

--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -565,7 +565,6 @@ int sockets_add(int sock, USockAddr *sa, int sid, int type,
 	int i;
 	char ra[50];
 	sockets *ss;
-	int lport = (sa && sa->lport > 0 && !(sa->sa.sa_data)) ? sa->lport : 0;
 
 	if (sock < 0 && sock != SOCK_TIMEOUT)
 		LOG_AND_RETURN(-1, "sockets_add does not add negative sockets %d", sock);

--- a/src/utils.c
+++ b/src/utils.c
@@ -697,28 +697,28 @@ void _log(char *file, int line, unsigned long level, char *fmt, ...)
 
 	switch (level)
 	{
-		case 0:                 lname = "****"; break;
-		case LOG_GENERAL:       lname = "----"; break;
-		case LOG_HTTP:  lname = "HTTP"; break;
-		case LOG_SOCKETWORKS:   lname = "WORK"; break;
-		case LOG_STREAM:        lname = "STRM"; break;
-		case LOG_ADAPTER:       lname = "ADPT"; break;
-		case LOG_SATIPC:        lname = "SIPC"; break;
-		case LOG_PMT:   lname = "PMT "; break;
-		case LOG_TABLES:        lname = "TBLS"; break;
-		case LOG_DVBAPI:        lname = "DAPI"; break;
-		case LOG_LOCK:  lname = "LOCK"; break;
-		case LOG_NETCEIVER:     lname = "NETC"; break;
-		case LOG_DVBCA: lname = "CA  "; break;
-		case LOG_AXE:   lname = "AXE "; break;
-		case LOG_SOCKET:        lname = "SOCK"; break;
-		case LOG_UTILS: lname = "UTIL"; break;
-		case LOG_DMX:   lname = "DMX "; break;
-		case LOG_SSDP:  lname = "SSDP"; break;
-		case LOG_DVB:   lname = "DVB "; break;
-		case LOG_RTSP:  lname = "RTSP"; break;
-			default:
-				lname = "????";
+		case 0:			lname = "****"; break;
+		case LOG_GENERAL:	lname = "----"; break;
+		case LOG_HTTP:		lname = "HTTP"; break;
+		case LOG_SOCKETWORKS:	lname = "WORK"; break;
+		case LOG_STREAM:	lname = "STRM"; break;
+		case LOG_ADAPTER:	lname = "ADPT"; break;
+		case LOG_SATIPC:	lname = "SIPC"; break;
+		case LOG_PMT:		lname = "PMT "; break;
+		case LOG_TABLES:	lname = "TBLS"; break;
+		case LOG_DVBAPI:	lname = "DAPI"; break;
+		case LOG_LOCK:		lname = "LOCK"; break;
+		case LOG_NETCEIVER:	lname = "NETC"; break;
+		case LOG_DVBCA:		lname = "CA  "; break;
+		case LOG_AXE:		lname = "AXE "; break;
+		case LOG_SOCKET:	lname = "SOCK"; break;
+		case LOG_UTILS:		lname = "UTIL"; break;
+		case LOG_DMX:		lname = "DMX "; break;
+		case LOG_SSDP:		lname = "SSDP"; break;
+		case LOG_DVB:		lname = "DVB "; break;
+		case LOG_RTSP:		lname = "RTSP"; break;
+				default:
+					lname = "????";
 	}
 	if (!fmt)
 	{

--- a/src/utils.c
+++ b/src/utils.c
@@ -675,12 +675,13 @@ char *get_current_timestamp_log(void)
 	return date_str;
 }
 
-void _log(char *file, int line, char *fmt, ...)
+void _log(char *file, int line, unsigned long level, char *fmt, ...)
 {
 	va_list arg;
 	int len = 0, len1 = 0, both = 0;
 	static int idx, times;
 	char stid[50];
+	char* lname;
 	static char output[2][2000]; // prints just the first 2000 bytes from the message
 
 	/* Check if the message should be logged */
@@ -690,10 +691,35 @@ void _log(char *file, int line, char *fmt, ...)
 	if (!opts.no_threads)
 	{
 		pthread_mutex_lock(&log_mutex);
-		snprintf(stid, sizeof(stid) - 2, " %s", thread_name);
+		snprintf(stid, sizeof(stid) - 2, "%*s", 6, thread_name);
 		stid[sizeof(stid) - 1] = 0;
 	}
 
+	switch (level)
+	{
+		case 0:                 lname = "****"; break;
+		case LOG_GENERAL:       lname = "----"; break;
+		case LOG_HTTP:  lname = "HTTP"; break;
+		case LOG_SOCKETWORKS:   lname = "WORK"; break;
+		case LOG_STREAM:        lname = "STRM"; break;
+		case LOG_ADAPTER:       lname = "ADPT"; break;
+		case LOG_SATIPC:        lname = "SIPC"; break;
+		case LOG_PMT:   lname = "PMT "; break;
+		case LOG_TABLES:        lname = "TBLS"; break;
+		case LOG_DVBAPI:        lname = "DAPI"; break;
+		case LOG_LOCK:  lname = "LOCK"; break;
+		case LOG_NETCEIVER:     lname = "NETC"; break;
+		case LOG_DVBCA: lname = "CA  "; break;
+		case LOG_AXE:   lname = "AXE "; break;
+		case LOG_SOCKET:        lname = "SOCK"; break;
+		case LOG_UTILS: lname = "UTIL"; break;
+		case LOG_DMX:   lname = "DMX "; break;
+		case LOG_SSDP:  lname = "SSDP"; break;
+		case LOG_DVB:   lname = "DVB "; break;
+		case LOG_RTSP:  lname = "RTSP"; break;
+			default:
+				lname = "????";
+	}
 	if (!fmt)
 	{
 		printf("NULL format at %s:%d !!!!!", file, line);
@@ -707,11 +733,11 @@ void _log(char *file, int line, char *fmt, ...)
 	else if (idx < 0)
 		idx = 0;
 	if (opts.file_line && !opts.slog)
-		len1 = snprintf(output[idx], sizeof(output[0]), "[%s%s] %s:%d: ",
-						get_current_timestamp_log(), stid, file, line);
+		len1 = snprintf(output[idx], sizeof(output[0]), "[%s %s %s] %s:%d: ",
+						get_current_timestamp_log(), lname, stid, file, line);
 	else if (!opts.slog)
-		len1 = snprintf(output[idx], sizeof(output[0]), "[%s%s]: ",
-						get_current_timestamp_log(), stid);
+		len1 = snprintf(output[idx], sizeof(output[0]), "[%s %s %s]: ",
+						get_current_timestamp_log(), lname, stid);
 	else if (opts.file_line)
 	{
 		len1 = 0;
@@ -1262,7 +1288,7 @@ int mutex_init(SMutex *mutex)
 	mutex->create_time = getTick();
 	mutex->enabled = 1;
 	mutex->state = 0;
-	LOG("Mutex init %p", mutex);
+	LOG("Mutex init OK %p", mutex);
 	return 0;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -351,7 +351,7 @@ int map_intd(char *s, char **v, int dv)
 		return atoi(s);
 	}
 	for (i = 0; v[i]; i++)
-		if (!strncasecmp(s, v[i], strlen(v[i])))
+		if (strlen(s) == strlen(v[i]) && !strncasecmp(s, v[i], strlen(v[i])))
 			n = i;
 	return n;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -183,7 +183,10 @@ static inline int get_index_hash(void *p, int max, int struct_size, uint32_t key
 	{                                                   \
 			_log(__FILE__, __LINE__, DEFAULT_LOG, a, ##__VA_ARGS__); \
 	}
-
+#define LOGG(level, a, ...)                                     \
+	{                                                   \
+			_log(__FILE__, __LINE__, level, a, ##__VA_ARGS__); \
+	}
 #define LOGM(a, ...) LOGL(DEFAULT_LOG, a, ##__VA_ARGS__)
 
 #define DEBUGL(level, a, ...)                           \

--- a/src/utils.h
+++ b/src/utils.h
@@ -112,7 +112,7 @@ void myfree(void *x, char *f, int l);
 char *header_parameter(char **arg, int i);
 char *get_current_timestamp();
 char *get_current_timestamp_log();
-void _log(char *file, int line, char *fmt, ...);
+void _log(char *file, int line, unsigned long level, char *fmt, ...);
 char *strip(char *s);
 int split(char **rv, char *s, int lrv, char sep);
 void set_signal_handler(char *argv0);
@@ -177,17 +177,19 @@ static inline int get_index_hash(void *p, int max, int struct_size, uint32_t key
 #define LOGL(level, a, ...)                             \
 	{                                                   \
 		if ((level)&opts.log)                           \
-			_log(__FILE__, __LINE__, a, ##__VA_ARGS__); \
+			_log(__FILE__, __LINE__, level, a, ##__VA_ARGS__); \
+	}
+#define LOG(a, ...)                                     \
+	{                                                   \
+			_log(__FILE__, __LINE__, DEFAULT_LOG, a, ##__VA_ARGS__); \
 	}
 
 #define LOGM(a, ...) LOGL(DEFAULT_LOG, a, ##__VA_ARGS__)
 
-#define LOG(a, ...) LOGL(1, a, ##__VA_ARGS__)
-
 #define DEBUGL(level, a, ...)                           \
 	{                                                   \
 		if ((level)&opts.debug)                         \
-			_log(__FILE__, __LINE__, a, ##__VA_ARGS__); \
+			_log(__FILE__, __LINE__, level, a, ##__VA_ARGS__); \
 	}
 #define DEBUGM(a, ...) DEBUGL(DEFAULT_LOG, a, ##__VA_ARGS__)
 
@@ -200,7 +202,7 @@ static inline int get_index_hash(void *p, int max, int struct_size, uint32_t key
 
 #define LOG0(a, ...)                                \
 	{                                               \
-		_log(__FILE__, __LINE__, a, ##__VA_ARGS__); \
+		_log(__FILE__, __LINE__, 0, a, ##__VA_ARGS__); \
 	}
 
 #define FAIL(a, ...)               \
@@ -251,24 +253,25 @@ static inline int get_index_hash(void *p, int max, int struct_size, uint32_t key
 			LOG("%-40s OK", #a);                                 \
 	}
 
-#define LOG_GENERAL 1
-#define LOG_HTTP (1 << 1)
-#define LOG_SOCKETWORKS (1 << 2)
-#define LOG_STREAM (1 << 3)
-#define LOG_ADAPTER (1 << 4)
-#define LOG_SATIPC (1 << 5)
-#define LOG_PMT (1 << 6)
-#define LOG_TABLES (1 << 7)
-#define LOG_DVBAPI (1 << 8)
-#define LOG_LOCK (1 << 9)
-#define LOG_NETCEIVER (1 << 10)
-#define LOG_DVBCA (1 << 11)
-#define LOG_AXE (1 << 12)
-#define LOG_SOCKET (1 << 13)
-#define LOG_UTILS (1 << 14)
-#define LOG_DMX (1 << 15)
-#define LOG_SSDP (1 << 16)
-#define LOG_DVB (1 << 17)
+#define LOG_GENERAL 1UL
+#define LOG_HTTP (1UL << 1)
+#define LOG_SOCKETWORKS (1UL << 2)
+#define LOG_STREAM (1UL << 3)
+#define LOG_ADAPTER (1UL << 4)
+#define LOG_SATIPC (1UL << 5)
+#define LOG_PMT (1UL << 6)
+#define LOG_TABLES (1UL << 7)
+#define LOG_DVBAPI (1UL << 8)
+#define LOG_LOCK (1UL << 9)
+#define LOG_NETCEIVER (1UL << 10)
+#define LOG_DVBCA (1UL << 11)
+#define LOG_AXE (1UL << 12)
+#define LOG_SOCKET (1UL << 13)
+#define LOG_UTILS (1UL << 14)
+#define LOG_DMX (1UL << 15)
+#define LOG_SSDP (1UL << 16)
+#define LOG_DVB (1UL << 17)
+#define LOG_RTSP (1UL << 18)
 
 typedef ssize_t (*mywritev)(int fd, const struct iovec *io, int len);
 
@@ -283,7 +286,7 @@ typedef ssize_t (*mywritev)(int fd, const struct iovec *io, int len);
 
 #ifdef UTILS_C
 char *loglevels[] =
-	{"general", "http", "socketworks", "stream", "adapter", "satipc", "pmt", "tables", "dvbapi", "lock", "netceiver", "ca", "axe", "socket", "utils", "dmx", "ssdp", "dvb", NULL};
+	{"general", "http", "socketworks", "stream", "adapter", "satipc", "pmt", "tables", "dvbapi", "lock", "netceiver", "ca", "axe", "socket", "utils", "dmx", "ssdp", "dvb", "rtsp", NULL};
 mywritev _writev = writev;
 #else
 extern char *loglevels[];


### PR DESCRIPTION
This patch improves the LOG part in some areas:
- Fixes a bug with some module names ("socketworks" can't be selected because is a substring of "socket").
- Fixes the unkown IP of the SAT>IP servers.
- Prints the name the of the module in each debug line.
- Prints the enabled module debug level of selected modules.
- Disambiguation of HTTP/RTSP protocols.
- Enhacement of some socket messages with incorrect values.
- Other minor changes.
