### PR TITLE
Support for reporting the closing of the socket

### DIFF
--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -605,6 +605,7 @@ int sockets_add(int sock, USockAddr *sa, int sid, int type,
 	ss->lbuf = 0;
 	ss->timeout_ms = 0;
 	ss->id = i;
+	ss->flags = 0;
 	ss->sock_err = 0;
 	ss->overflow = 0;
 	ss->buf_alloc = ss->buf_used = 0;

--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -924,6 +924,25 @@ void *select_and_execute(void *arg)
 							get_sockaddr_port(ss->sa), types[ss->type], err);
 						if (err == EOVERFLOW || err == EWOULDBLOCK)
 							continue;
+						if ((ss->flags & 2) && rlen == 0)
+						{
+							LOGM("select_and_execute[%d]: reporting that the remote client has closed the socket (rlen: %d, flags:%d)",
+							     i, ss->rlen, ss->flags);
+							ss->rlen = -1;  // This indicates that the remote end has closed the socket
+							errno = ss->action(ss);
+							ss->rlen = 0;   // Restore the value previoius to the call
+
+							if (errno < 0)
+							{
+								LOG("closing report of socket_id %d failed sid %d return err %d: %s",
+								    i, ss->sid, errno, strerror(errno));
+							}
+							else
+							{
+								LOGM("closing report of socket_id %d OK", i, ss->sid);
+								continue;
+							}
+						}
 						if (err == EAGAIN)
 						{
 							ss->err++;
@@ -1204,6 +1223,14 @@ void set_socket_receive_buffer(int sock, int len)
 	sl = sizeof(int);
 	if (!getsockopt(sock, SOL_SOCKET, SO_RCVBUF, &len, &sl))
 		LOG("receive socket buffer size is %d bytes", len);
+}
+
+void set_socket_disconnect_flag(int sock)
+{
+	sockets *ss = get_sockets(sock);
+	if (!ss)
+		return;
+	ss->flags |= 2;
 }
 
 void set_socket_pos(int sock, int pos)

--- a/src/socketworks.h
+++ b/src/socketworks.h
@@ -106,6 +106,7 @@ void free_pack(SNPacket *p);
 void sockets_setread(int i, void *r);
 void set_socket_send_buffer(int sock, int len);
 void set_socket_receive_buffer(int sock, int len);
+void set_socket_disconnect_flag(int sock);
 void set_socket_pos(int sock, int pos);
 void set_sock_lock(int i, SMutex *m);
 void set_socket_thread(int s_id, pthread_t tid);


### PR DESCRIPTION
In the loop of sockets activity a new check is added for reporting to the adapter that the socket is closed.

This new functionality is based on this:
- The report is done calling to the function `action()` with a negative `rlen` size.
- This call is only done if the adapter understand this new semantic.
- To enable this new semantic for a socket it's required to use the new function `set_socket_disconnect_flag()`.
- When reporting the close when returning from `action()` the return value indicates: >=0 --> OK; <0 --> ERROR.
- When responding with error, the general behaviour is executed. When responding with ok, the loop continues.

The new behavioiur can be used to trigger some action in the adapter when this case is detected. In general, if the adapter catch this action, then the adapter will not be closed when the sockets is closed.