### PR TITLE
FIX of debug -l socketworks

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -682,7 +682,7 @@ void set_options(int argc, char *argv[]) {
             strncpy(buf, optarg, sizeof(buf) - 1);
             int la = split(arg, buf, ARRAY_SIZE(arg), ',');
             for (i = 0; i < la; i++) {
-                int level = map_intd(arg[i], loglevels, -1);
+                int level = maps_intd(arg[i], loglevels, -1);
                 if (level == -1) {
                     if (!strcmp(arg[i], "-l")) {
                         LOG("The LOG option has changed, please run "

--- a/src/utils.c
+++ b/src/utils.c
@@ -367,6 +367,31 @@ int map_intd(char *s, char **v, int dv) {
     return n;
 }
 
+int maps_intd(char *s, char **v, int dv) {
+    int i, n = dv;
+
+    if (s == NULL) {
+        LOG_AND_RETURN(dv, "maps_intd: s=>NULL, v=%p, %s %s", v,
+                       v ? v[0] : "NULL", v ? v[1] : "NULL");
+    }
+
+    s = strip(s);
+
+    if (!*s)
+        LOG_AND_RETURN(dv, "maps_intd: s is empty");
+
+    if (v == NULL) {
+        if (s[0] != '+' && s[0] != '-' && (s[0] < '0' || s[0] > '9'))
+            LOG_AND_RETURN(dv, "maps_intd: s not a number: %s, v=%p, %s %s", s,
+                           v, v ? v[0] : "NULL", v ? v[1] : "NULL");
+        return atoi(s);
+    }
+    for (i = 0; v[i]; i++)
+        if (strlen(s) <= strlen(v[i]) && !strncasecmp(s, v[i], strlen(v[i])))
+            n = i;
+    return n;
+}
+
 char *header_parameter(char **arg,
                        int i) // get the value of a header parameter
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -134,6 +134,7 @@ int setItemLen(SHashTable *hash, uint32_t key, int len);
 int split(char **rv, char *s, int lrv, char sep);
 int map_int(char *s, char **v);
 int map_intd(char *s, char **v, int dv);
+int maps_intd(char *s, char **v, int dv);
 int map_float(char *s, int mul);
 void *mymalloc(int a, char *f, int l);
 void *myrealloc(void *p, int a, char *f, int l);


### PR DESCRIPTION
When enabling the debug of the "socketworks" module the enabled module is the "socket" one, becase the name "socket" is contained inside "socketworks".
This fixes the problem enabling only a module when the exact name matches. To do this is used a new function `maps_intd()` that is used only here.