### PR TITLE
Fix missing PCR pid

### DIFF
--- a/src/pmt.c
+++ b/src/pmt.c
@@ -1624,15 +1624,16 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
     pmt_len = len - 4;
 
     pi_len = ((b[10] & 0xF) << 8) + b[11];
+    pcr_pid = ((b[8] & 0x1F) << 8) + b[9];
 
     pmt->sid = b[3] * 256 + b[4];
     pmt->version = ver;
 
     mutex_lock(&pmt->mutex);
-    LOG("new PMT %d AD %d, pid: %04X (%d), len %d, pi_len %d, ver %d, sid "
+    LOG("new PMT %d AD %d, pid: %04X (%d), len %d, pi_len %d, ver %d, pcr %d, sid "
         "%04X "
         "(%d) %s %s",
-        pmt->id, ad->id, pid, pid, pmt_len, pi_len, ver, pmt->sid, pmt->sid,
+        pmt->id, ad->id, pid, pid, pmt_len, pi_len, ver, pcr_pid, pmt->sid, pmt->sid,
         pmt->name[0] ? "channel:" : "", pmt->name);
     pi = b + 12;
     pmt_b = pi + pi_len;
@@ -1706,6 +1707,7 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
             cp->pmt = pmt->master_pmt;
         }
     }
+    // Add the PCR pid if it's independent
 
     if (pmt->first_active_pid < 0)
         pmt->first_active_pid = pmt->active_pid[0];

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -1559,7 +1559,7 @@ int get_master_pmt_for_pid(int aid, int pid) {
 }
 
 int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
-    int pi_len = 0, isAC3, pmt_len = 0, i, es_len, ver;
+    int pi_len = 0, isAC3, pmt_len = 0, i, es_len, ver, pcr_pid;
     int enabled_channels = 0;
     unsigned char *pmt_b, *pi;
     int pid, spid, stype;


### PR DESCRIPTION
When the PCR of a service is independent (i.e., it has no associated stream) the PCR pid is not added to the list of the pids. This patch fixes this problem. So when simulating the `pids=all` in E2 boxes the PCR pid is added to the list of pids.