### PR TITLE
Pass NULL packets when pids=all is emulated

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Help
 	- note: * as adapter means apply to all adapters
 
 * -E Allows encrypted stream to be sent to the client even if the decrypting is unsuccessful
- 
+	- note: when pids=all is emulated this pass NULLs too
+
 * -Y --delsys ADAPTER1:DELIVERY_SYSTEM1[,ADAPTER2:DELIVERY_SYSTEM2[,..]] - specify the delivery system of the adapters (0 is the first adapter)	
 	* eg: --delsys 0:dvbt,1:dvbs
 	- specifies adapter 0 as a DVBT device, adapter 1 as DVB-S, which overrides the system detection of the adapter

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -330,6 +330,7 @@ Help\n\
 	- note: * as adapter means apply to all adapters\n\
 \n\
 * -E Allows encrypted stream to be sent to the client even if the decrypting is unsuccessful\n \
+	- note: when pids=all is emulated this pass NULLs too\n\
 \n\
 * -Y --delsys ADAPTER1:DELIVERY_SYSTEM1[,ADAPTER2:DELIVERY_SYSTEM2[,..]] - specify the delivery system of the adapters (0 is the first adapter)	\n\
 	* eg: --delsys 0:dvbt,1:dvbs\n\

--- a/src/minisatip.h
+++ b/src/minisatip.h
@@ -12,6 +12,7 @@
 #endif
 
 #define EMU_PIDS_ALL_ENFORCED_PIDS_LIST 1, 16, 17, 18, 20, 21
+#define EMU_PIDS_ALL_ENFORCED_WITH_NULL 1, 16, 17, 18, 20, 21, 8181
 
 void set_options(int argc, char *argv[]);
 

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -1905,7 +1905,10 @@ void emulate_add_all_pids(adapter *ad) {
                             updated = 1;
                         }
 
-            int forced_pids[] = {EMU_PIDS_ALL_ENFORCED_PIDS_LIST};
+            int *forced_pids;
+            int list_plain[]     = {EMU_PIDS_ALL_ENFORCED_PIDS_LIST};
+            int list_with_null[] = {EMU_PIDS_ALL_ENFORCED_WITH_NULL};
+            forced_pids = (ad->drop_encrypted) ? list_plain : list_with_null;
             int i_forced = sizeof(forced_pids) / sizeof(int);
             for (j = 0; j < i_forced; j++) {
                 int fpid = forced_pids[j];


### PR DESCRIPTION
When the pids=all is emulated it will be useful to receive the NULL stuff in some circunstances.
Instead of pass all NULLs by default, this is only activated when `-E` (pass unencrypted) is set.