### PR TITLE
Calculate SNR dB to Percentage based on Modulation

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -114,6 +114,7 @@ adapter *adapter_alloc() {
 
     ad->strength_multiplier = opts.strength_multiplier;
     ad->snr_multiplier = opts.snr_multiplier;
+    ad->db_snr_map = 1.0;
 
     ad->drop_encrypted = opts.drop_encrypted;
 
@@ -429,6 +430,7 @@ int close_adapter(int na) {
     ad->dvr = 0;
     ad->strength = 0;
     ad->snr = 0;
+    ad->db_snr_map = 1.0;
 #ifndef AXE
     ad->old_diseqc = -1;
     ad->old_hiband = -1;
@@ -986,6 +988,7 @@ int tune(int aid, int sid) {
         ad->wait_new_stream = 1;
         ad->strength = 0;
         ad->snr = 0;
+        ad->db_snr_map = 1.0;
         flush_data = 1;
         ad->is_t2mi = 0;
         set_socket_pos(ad->sock, 0); // flush the existing buffer

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -58,9 +58,9 @@ struct struct_adapter {
     uint16_t strength; // strength have values between 0 and 255
     uint32_t ber;
     uint16_t snr; // strength have values between 0 and 255
-    float strength_multiplier,
-        snr_multiplier;        // final value: strength *
-                               // strength_multipler, same for snr
+    float strength_multiplier, // final value: strength * strength_multipler,
+          snr_multiplier;      // same for snr
+    float db_snr_map;          // modulation scale value for dB SNR conversion
     uint32_t pid_err, dec_err; // detect pids received but not part of any
                                // stream, decrypt errors
     diseqc diseqc_param;

--- a/src/dvb.c
+++ b/src/dvb.c
@@ -340,6 +340,234 @@ void copy_dvb_parameters(transponder *s, transponder *d) {
         d->x_pmt ? d->x_pmt : "NULL");
 }
 
+// This function provides an scale factor for dB to percentage conversion,
+// based on the modulation. The top is the standard OK signal value in dB.
+float get_db_snr_map(transponder *tp) {
+    float db_map;
+    int top = 10; // Default factor 1.0: dB value ==> % (3dB => 3%)
+
+    switch (tp->sys) {
+
+    case SYS_DVBC_ANNEX_AC:
+    case SYS_DVBC_ANNEX_B:
+    case SYS_DVBC_ANNEX_C: /* not sure, to be tested */
+        switch (tp->mtype) {
+
+        case QAM_256:
+            top = DVB_C__QAM_256__FEC_NONE;
+            break;
+
+        case QAM_64:
+            top = DVB_C__QAM_64___FEC_NONE;
+            break;
+
+        default:
+            top = DVB_C__OTHER;
+            LOG("get_db_snr_map -> Mudulation SNR scale mapping DVB-C not tested !!");
+        }
+        break;
+
+    case SYS_DVBS:
+        switch (tp->mtype) {
+
+        case QPSK:
+            switch (tp->fec) {
+
+            case FEC_1_2:
+                top = DVB_S__QPSK__FEC_1_2;
+                break;
+
+            case FEC_2_3:
+                top = DVB_S__QPSK__FEC_2_3;
+                break;
+
+            case FEC_3_4:
+                top = DVB_S__QPSK__FEC_3_4;
+                break;
+
+            case FEC_5_6:
+                top = DVB_S__QPSK__FEC_5_6;
+                break;
+
+            case FEC_7_8:
+                top = DVB_S__QPSK__FEC_7_8;
+                break;
+
+            default:
+                top = DVB_S__OTHER;
+            }
+
+        default:
+            top = DVB_S__OTHER;
+            LOG("get_db_snr_map -> Mudulation SNR scale mapping DVB-S not tested !!");
+        }
+        break;
+
+    case SYS_DVBS2:
+        switch (tp->mtype) {
+
+        case QPSK:
+        switch (tp->fec) {
+
+            case FEC_1_2:
+                top = DVB_S2_QPSK__FEC_1_2;
+                break;
+
+            case FEC_2_3:
+                top = DVB_S2_QPSK__FEC_2_3;
+                break;
+
+            case FEC_3_4:
+                top = DVB_S2_QPSK__FEC_3_4;
+                break;
+
+            case FEC_5_6:
+                top = DVB_S2_QPSK__FEC_5_6;
+                break;
+
+            case FEC_8_9:
+                top = DVB_S2_QPSK__FEC_8_9;
+                break;
+
+            case FEC_9_10:
+                top = DVB_S2_QPSK__FEC_9_10;
+                break;
+
+            default:
+                top = DVB_S2_OTHER;
+            }
+
+        case PSK_8:
+        switch (tp->fec) {
+
+            case FEC_2_3:
+                top = DVB_S2_PSK_8_FEC_2_3;
+                break;
+
+            case FEC_3_4:
+                top = DVB_S2_PSK_8_FEC_3_4;
+                break;
+
+            case FEC_5_6:
+                top = DVB_S2_PSK_8_FEC_5_6;
+                break;
+
+            case FEC_8_9:
+                top = DVB_S2_PSK_8_FEC_8_9;
+                break;
+
+            default:
+                top = DVB_S2_PSK_8_OTHER;
+            }
+
+        default:
+            top = DVB_S2_OTHER;
+            LOG("get_db_snr_map -> Mudulation SNR scale mapping DVB-S2 not tested !!");
+        }
+        break;
+
+    case SYS_DVBT:
+    case SYS_DVBT2: /* not sure, to be tested */
+        switch (tp->mtype) {
+
+        case QPSK:
+        switch (tp->fec) {
+
+            case FEC_1_2:
+                top = DVB_T__QPSK__FEC_1_2;
+                break;
+
+            case FEC_2_3:
+                top = DVB_T__QPSK__FEC_2_3;
+                break;
+
+            case FEC_3_4:
+                top = DVB_T__QPSK__FEC_3_4;
+                break;
+
+            case FEC_5_6:
+                top = DVB_T__QPSK__FEC_5_6;
+                break;
+
+            case FEC_7_8:
+                top = DVB_T__QPSK__FEC_7_8;
+                break;
+
+            default:
+                top = DVB_T__QPSK_OTHER;
+            }
+
+        case QAM_16:
+        switch (tp->fec) {
+
+            case FEC_1_2:
+                top = DVB_T__QAM16_FEC_1_2;
+                break;
+
+            case FEC_2_3:
+                top = DVB_T__QAM16_FEC_2_3;
+                break;
+
+            case FEC_3_4:
+                top = DVB_T__QAM16_FEC_3_4;
+                break;
+
+            case FEC_5_6:
+                top = DVB_T__QAM16_FEC_5_6;
+                break;
+
+            case FEC_7_8:
+                top = DVB_T__QAM16_FEC_7_8;
+                break;
+
+            default:
+                top = DVB_T__QAM16_OTHER;
+            }
+
+        case QAM_64:
+        switch (tp->fec) {
+
+            case FEC_1_2:
+                top = DVB_T__QAM64_FEC_1_2;
+                break;
+
+            case FEC_2_3:
+                top = DVB_T__QAM64_FEC_2_3;
+                break;
+
+            case FEC_3_4:
+                top = DVB_T__QAM64_FEC_3_4;
+                break;
+
+            case FEC_5_6:
+                top = DVB_T__QAM64_FEC_5_6;
+                break;
+
+            case FEC_7_8:
+                top = DVB_T__QAM64_FEC_7_8;
+                break;
+
+            default:
+                top = DVB_T__QAM64_OTHER;
+            }
+
+        default:
+            top = DVB_T__QAM64_OTHER;
+            LOG("get_db_snr_map -> Mudulation SNR scale mapping DVB-T not tested !!");
+        }
+        break;
+
+    default:
+        LOG("get_db_snr_map -> Mudulation SNR scale mapping unkown !!");
+    }
+
+    db_map = top / 10.0; // top is dB*10
+    LOGM("get_db_snr_map -> src=%d, fe=%d, msys=%d, mtype=%d, fec=%d, db_map=%f",
+         tp->diseqc, tp->fe, tp->sys, tp->mtype, tp->fec, db_map);
+
+    return db_map;
+}
+
 #ifndef DISABLE_LINUXDVB
 
 struct diseqc_cmd {
@@ -971,6 +1199,8 @@ int dvb_tune(int aid, transponder *tp) {
     }
 #endif
 
+    ad->db_snr_map = get_db_snr_map(&ad->tp);
+
     return 0;
 }
 
@@ -1409,9 +1639,8 @@ int get_signal_new(adapter *ad, int *status, uint32_t *ber, uint16_t *strength,
         snrd = enum_cmdargs[1].u.st.stat[0].uvalue;
     } else if (enum_cmdargs[1].u.st.stat[0].scale == FE_SCALE_DECIBEL) {
         snr_s = "dB";
-        init_snr = enum_cmdargs[1].u.st.stat[0].svalue; // dB / 1000
-        snrd =
-            init_snr * 65535.0 / (100 * 1000); // dB value ==> %  ( 3 dB => 3%)
+        init_snr = enum_cmdargs[1].u.st.stat[0].svalue; // dB * 1000
+        snrd = init_snr * 65535.0 / (100 * 1000 * ad->db_snr_map);
     }
     //	else if (enum_cmdargs[1].u.st.stat[0].scale == 0)
     //		err |= 2;

--- a/src/dvb.h
+++ b/src/dvb.h
@@ -159,6 +159,55 @@ typedef enum fe_pls_mode {
     PLS_MODE_COMBO,
 } fe_pls_mode_t;
 
+// dB scale ( dB*10 for Integer enum )
+typedef enum dvb_snr_table {
+	DVB_C__QAM_256__FEC_NONE =  340 ,
+	DVB_C__QAM_64___FEC_NONE =  300 ,
+	DVB_C__OTHER             =  350 ,
+
+	DVB_S__QPSK__FEC_1_2     =   70 ,
+	DVB_S__QPSK__FEC_2_3     =   90 ,
+	DVB_S__QPSK__FEC_3_4     =  100 ,
+	DVB_S__QPSK__FEC_5_6     =  110 ,
+	DVB_S__QPSK__FEC_7_8     =  120 ,
+	DVB_S__OTHER             =  150 ,
+
+	DVB_S2_QPSK__FEC_1_2     =   90 ,
+	DVB_S2_QPSK__FEC_2_3     =  110 ,
+	DVB_S2_QPSK__FEC_3_4     =  120 ,
+	DVB_S2_QPSK__FEC_5_6     =  120 ,
+	DVB_S2_QPSK__FEC_8_9     =  130 ,
+	DVB_S2_QPSK__FEC_9_10    =  135 ,
+	DVB_S2_OTHER             =  150 ,
+
+	DVB_S2_PSK_8_FEC_2_3     =  145 ,
+	DVB_S2_PSK_8_FEC_3_4     =  160 ,
+	DVB_S2_PSK_8_FEC_5_6     =  175 ,
+	DVB_S2_PSK_8_FEC_8_9     =  190 ,
+	DVB_S2_PSK_8_OTHER       =  200 ,
+
+	DVB_T__QPSK__FEC_1_2     =   41 ,
+	DVB_T__QPSK__FEC_2_3     =   61 ,
+	DVB_T__QPSK__FEC_3_4     =   72 ,
+	DVB_T__QPSK__FEC_5_6     =   85 ,
+	DVB_T__QPSK__FEC_7_8     =   92 ,
+	DVB_T__QPSK_OTHER        =  100 ,
+
+	DVB_T__QAM16_FEC_1_2     =   98 ,
+	DVB_T__QAM16_FEC_2_3     =  121 ,
+	DVB_T__QAM16_FEC_3_4     =  134 ,
+	DVB_T__QAM16_FEC_5_6     =  148 ,
+	DVB_T__QAM16_FEC_7_8     =  157 ,
+	DVB_T__QAM16_OTHER       =  180 ,
+
+	DVB_T__QAM64_FEC_1_2     =  140 ,
+	DVB_T__QAM64_FEC_2_3     =  199 ,
+	DVB_T__QAM64_FEC_3_4     =  249 ,
+	DVB_T__QAM64_FEC_5_6     =  213 ,
+	DVB_T__QAM64_FEC_7_8     =  220 ,
+	DVB_T__QAM64_OTHER       =  250 ,
+} dvb_snr_table_t;
+
 #if DVBAPIVERSION < 0x0505
 #define DTV_ENUM_DELSYS 44
 #define SYS_DVBC_ANNEX_A SYS_DVBC_ANNEX_AC
@@ -292,6 +341,7 @@ int detect_dvb_parameters(char *s, transponder *tp);
 void init_dvb_parameters(transponder *tp);
 void copy_dvb_parameters(transponder *s, transponder *d);
 
+float get_db_snr_map(transponder *tp);
 uint32_t pls_scrambling_index(transponder *tp);
 
 char *get_pilot(int i);


### PR DESCRIPTION
This patch incorporates a SNR value conversion from dB scale to percentage scale.
To do it, it uses a table of the correct dB values for each modulation. These values correspond to a 100% good signal.
The table includes at time only the common modulations. Other values could be included in the future.
  