### PR TITLE
Fixing the dB value and colorization

### DIFF
--- a/html/status.html
+++ b/html/status.html
@@ -368,18 +368,20 @@
 						var snr = parseInt(state['ad_snr'][i] / 0.15);
 
 					var snrdb = parseInt(state['ad_db'][i]);
-
+					
+					var snr_color;
+					if (snr<=25 && snr>=0) snr_color="progress-1";
+					if (snr<=42 && snr>25) snr_color="progress-2";
+					if (snr<=60 && snr>42) snr_color="progress-3";
+					if (snr<=80 && snr>60) snr_color="progress-4";
+					if (snr<=100 && snr>80) snr_color="progress-5";
+					
 					if (snrdb >= 65535) // "65535" is the MAX_DB value
 						signal += "<div class='level'>SNR <progress class='psnr " + snr_color + "' value='" + snr + "' max='100' />" + snr + "%</div><br />";
 					else {
-						snrdb = snrdb / 0.1;
+						snrdb = snrdb / 10;
 						//SNR progressbar color scaling
-						var snr_color;
-						if (snr<=25 && snr>=0) snr_color="progress-1";
-						if (snr<=42 && snr>25) snr_color="progress-2";
-						if (snr<=60 && snr>42) snr_color="progress-3";
-						if (snr<=80 && snr>60) snr_color="progress-4";
-						if (snr<=100 && snr>80) snr_color="progress-5";
+
 
 						signal += "<div class='level'><div class='db'>" + snrdb + "dB</div>SNR <progress class='psnr " + snr_color + "' value='" + snr + "' max='100' />" + snr + "%</div><br />";
 					}


### PR DESCRIPTION
dB value was incorrectly divided
Colorization of snr progress bar was not working when there is no dB value available