### PR TITLE
Add new Tuner status enforcement 

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -108,6 +108,8 @@ adapter *adapter_alloc() {
 
     ad->strength_multiplier = opts.strength_multiplier;
     ad->snr_multiplier = opts.snr_multiplier;
+    ad->force_strength_mode = 0;
+    ad->force_snr_mode = 0;
     ad->db_snr_map = 1.0;
 
     ad->drop_encrypted = opts.drop_encrypted;
@@ -1962,6 +1964,7 @@ void set_adapters_delsys(char *o) {
 void set_signal_multiplier(char *o) {
     int i, la, a_id;
     float strength_multiplier, snr_multiplier;
+    char force_strength_mode, force_snr_mode;
     char buf[1000], *arg[40], *sep1, *sep2;
     adapter *ad;
     SAFE_STRCPY(buf, o);
@@ -1986,14 +1989,28 @@ void set_signal_multiplier(char *o) {
         if (!sep1 || !sep2)
             continue;
 
-        strength_multiplier = strtod(sep1 + 1, NULL);
-        snr_multiplier = strtod(sep2 + 1, NULL);
+        if (sep1[1]=='%' || sep1[1]=='#') {
+            force_strength_mode = sep1[1]=='%'? 1 : 2;
+            strength_multiplier = strtod(sep1 + 2, NULL);
+        } else {
+            force_strength_mode = 0;
+            strength_multiplier = strtod(sep1 + 1, NULL);
+        }
+        if (sep2[1]=='%' || sep2[1]=='#') {
+            force_snr_mode = sep2[1]=='%'? 1 : 2;
+            snr_multiplier = strtod(sep2 + 2, NULL);
+        } else {
+            force_snr_mode = 0;
+            snr_multiplier = strtod(sep2 + 1, NULL);
+        }
         if (strength_multiplier < 0 || snr_multiplier < 0)
             continue;
 
         if (ad) {
             ad->strength_multiplier = strength_multiplier;
             ad->snr_multiplier = snr_multiplier;
+            ad->force_strength_mode = force_strength_mode;
+            ad->force_snr_mode = force_snr_mode;
         } else {
             opts.strength_multiplier = strength_multiplier;
             opts.snr_multiplier = snr_multiplier;
@@ -2004,9 +2021,13 @@ void set_signal_multiplier(char *o) {
                     a[j]->snr_multiplier = snr_multiplier;
                 }
         }
-        LOG("Setting signal multipler for adapter %d strength_multiplier %.2f "
+        LOG("Setting signal multipler for adapter %d%s%s "
+            "strength_multiplier %.2f "
             "snr_multiplier %.2f",
-            a_id, (double)strength_multiplier, (double)snr_multiplier);
+            a_id,
+            force_strength_mode>0? (force_strength_mode>1? " (forced strength decibel)" : " (forced strength relative)") : "",
+            force_snr_mode>0? (force_snr_mode>1? " (forced snr decibel)" : " (forced snr relative)") : "",
+            (double)strength_multiplier, (double)snr_multiplier);
     }
 }
 

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -1989,15 +1989,15 @@ void set_signal_multiplier(char *o) {
         if (!sep1 || !sep2)
             continue;
 
-        if (sep1[1]=='%' || sep1[1]=='#') {
-            force_strength_mode = sep1[1]=='%'? 1 : 2;
+        if (sep1[1]=='#' || sep1[1]=='@') {
+            force_strength_mode = sep1[1]=='#'? 1 : 2;
             strength_multiplier = strtod(sep1 + 2, NULL);
         } else {
             force_strength_mode = 0;
             strength_multiplier = strtod(sep1 + 1, NULL);
         }
-        if (sep2[1]=='%' || sep2[1]=='#') {
-            force_snr_mode = sep2[1]=='%'? 1 : 2;
+        if (sep2[1]=='#' || sep2[1]=='@') {
+            force_snr_mode = sep2[1]=='#'? 1 : 2;
             snr_multiplier = strtod(sep2 + 2, NULL);
         } else {
             force_snr_mode = 0;

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -64,6 +64,8 @@ struct struct_adapter {
     uint16_t db;  // if MAX_DB then no value, else value is dB*10 of the adapter
     float strength_multiplier, // final value: strength * strength_multipler,
         snr_multiplier;        // same for snr
+    char force_strength_mode,  // 0: No force (default) 1: Force Relative 2: Force Decibel
+        force_snr_mode;        // same for snr
     float db_snr_map;          // modulation scale value for dB SNR conversion
     uint32_t pid_err, dec_err; // detect pids received but not part of any
                                // stream, decrypt errors

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -402,6 +402,9 @@ Help\n\
 	* If the snr or the strength multipliers are set to 0, minisatip will override the value received from the adapter and will report always full signal 100%% \n\
 	* eg: -M 4-6:1.2-1.3 - multiplies the strength with 1.2 and the snr with 1.3 for adapter 4, 5 and 6\n\
 	* eg: -M *:1.5-1.6 - multiplies the strength with 1.5 and the snr with 1.6 for all adapters\n\
+	* [#] This symbol forces to read values as percentage\n\
+	* [@] This symbol forces to read values as decibels\n\
+	* eg: -M *:#1.0-@1.0 - not multiply the strength but force it as percentage and for the snr interpret it as decibels\n\
 \n\
 * -N --disable-dvb disable DVB adapter detection\n \
 \n\


### PR DESCRIPTION
For some adapters the DVB API version 5.5 is not available. In these cases the software can't distinguish the status reporting of the tuners. Therefore, the values of Strength and/or SNR could be incorrect. If you know how the driver of the tuner reports the data (in percentage or in dB), then you could tweak the values with the `-M --multiplier` parameter.

This patch adds the option to enforce percentage or decibel modes at tuner level (because you can mix different hardware and drivers in the same machine). Example:

`-M 0:#1.0-@1.0 -M 1:#1.0-@1.0 -M 2:2.0-1.0 -M 3:2.0-1.0`

In this case the first two tuners (DVB-S) use default values enforcing "percentage" for Strength and "dB" for SNR. And for the other two tuners (DVB-T2) the types aren't enforced but the Strength is doubled.

This removes all dependencies for Enigma2 boxes, and you will have the opportunity to set the correct types/values for all of your tuners.
