### PR TITLE
Restore socket buffer configuration

### DIFF
--- a/src/opts.h
+++ b/src/opts.h
@@ -30,6 +30,7 @@ struct struct_opts {
     int device_id;
     int bootid;
     int dvr_buffer;
+    int satipc_buffer;
     int adapter_buffer;
     int output_buffer;
     int udp_threshold;

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -570,6 +570,8 @@ int satipc_open_device(adapter *ad) {
                                          (socket_action)satipc_close, NULL);
         }
         sockets_timeout(ad->fe_sock, 25000); // 25s
+        if (opts.satipc_buffer > 0)
+            set_socket_receive_buffer(ad->dvr, opts.satipc_buffer);
         if (ad->fe_sock < 0 || sip->rtcp_sock < 0 || ad->dvr < 0 ||
             sip->rtcp < 0) {
             if (sip->rtcp_sock >= 0)
@@ -587,6 +589,8 @@ int satipc_open_device(adapter *ad) {
     } else {
         ad->dvr = ad->fe;
         ad->fe = -1;
+        if (opts.satipc_buffer > 0)
+            set_socket_receive_buffer(ad->dvr, opts.satipc_buffer);
         ad->fe_sock = sockets_add(SOCK_TIMEOUT, NULL, ad->id, TYPE_UDP, NULL,
                                   NULL, (socket_action)satipc_timeout);
         sockets_timeout(ad->fe_sock, 25000); // 25s

--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -1109,6 +1109,39 @@ void free_all() {
 #endif
 }
 
+void set_socket_send_buffer(int sock, int len) {
+    int sl;
+    int rv = 0;
+    if (len <= 0)
+        return;
+// len = 8*1024; /* have a nice testing !!!! */
+#ifdef SO_SNDBUFFORCE
+    if ((rv = setsockopt(sock, SOL_SOCKET, SO_SNDBUFFORCE, &len, sizeof(len))))
+        LOG("unable to set output socket buffer (force) size to %d", len);
+#endif
+    if (rv && setsockopt(sock, SOL_SOCKET, SO_SNDBUF, &len, sizeof(len)))
+        LOG("unable to set output socket buffer size to %d", len);
+    sl = sizeof(int);
+    if (!getsockopt(sock, SOL_SOCKET, SO_SNDBUF, &len, (socklen_t *)&sl))
+        LOG("output socket buffer size for socket %d is %d bytes", sock, len);
+}
+
+void set_socket_receive_buffer(int sock, int len) {
+    socklen_t sl;
+    int rv = 0;
+    if (len <= 0)
+        return;
+#ifdef SO_RCVBUFFORCE
+    if ((rv = setsockopt(sock, SOL_SOCKET, SO_RCVBUFFORCE, &len, sizeof(len))))
+        LOG("unable to set receive socket buffer (force) size to %d", len);
+#endif
+    if (rv && setsockopt(sock, SOL_SOCKET, SO_RCVBUF, &len, sizeof(len)))
+        LOG("unable to set receive socket buffer size to %d", len);
+    sl = sizeof(int);
+    if (!getsockopt(sock, SOL_SOCKET, SO_RCVBUF, &len, &sl))
+        LOG("receive socket buffer size is %d bytes", len);
+}
+
 void set_socket_pos(int sock, int pos) {
     sockets *ss = get_sockets(sock);
     if (!ss)

--- a/src/socketworks.h
+++ b/src/socketworks.h
@@ -109,6 +109,8 @@ void free_all();
 void free_pack(SNPacket *p);
 void sockets_setread(int i, void *r);
 void sockets_setclose(int i, void *r);
+void set_socket_send_buffer(int sock, int len);
+void set_socket_receive_buffer(int sock, int len);
 void set_socket_pos(int sock, int pos);
 void set_sock_lock(int i, SMutex *m);
 void set_socket_thread(int s_id, pthread_t tid);

--- a/src/stream.c
+++ b/src/stream.c
@@ -413,6 +413,8 @@ int decode_transport(sockets *s, char *arg, char *default_rtp, int start_rtp) {
             memcpy(&sid->sa, &s->sa, sizeof(s->sa));
             if (!set_linux_socket_nonblock(s->sock))
                 s->nonblock = 1;
+            if (opts.output_buffer > 0)
+                set_socket_send_buffer(s->sock, opts.output_buffer);
             return 0;
         }
 
@@ -492,6 +494,8 @@ int decode_transport(sockets *s, char *arg, char *default_rtp, int start_rtp) {
                              (socket_action)close_stream_for_socket, NULL)) < 0)
             LOG_AND_RETURN(-1, "RTP sockets_add failed");
 
+        if (opts.output_buffer > 0)
+            set_socket_send_buffer(sid->rsock, opts.output_buffer);
         set_socket_dscp(sid->rsock, IPTOS_DSCP_EF, 7);
 
         if ((sid->rtcp =


### PR DESCRIPTION
This patch restores the lost option to set the socket buffers. However, now it's possible to set independently the read socket buffer for the satipc connections, and the write socket buffer for the clients. By default the buffer uses the kernel configuration. However, with two new parameters the user can overwrite them.
