### PR TITLE
Add adapter restrictions

### DIFF
--- a/src/adapter.h
+++ b/src/adapter.h
@@ -89,6 +89,9 @@ struct struct_adapter {
     int threshold;
     int active_pids, max_active_pids, max_pids;
     int active_demux_pids;
+    int active_services;
+    int adapter_dmx_bandwith; // TODO: pending to calculate!
+    int max_services, max_runpids, max_bandwith;
     int is_t2mi;
     uint64_t tune_time;
     pthread_t thread;
@@ -161,6 +164,7 @@ void set_diseqc_timing(char *o);
 void set_diseqc_multi(char *o);
 void set_slave_adapters(char *o);
 void set_timeout_adapters(char *o);
+void set_restrictions_adapters(char *o);
 void set_adapter_dmxsource(char *o);
 void reset_pids_type(int aid, int clear_pat);
 void reset_ecm_type_for_pmt(int aid, int pmt);
@@ -179,6 +183,7 @@ void set_signal_multiplier(char *o);
 int signal_thread(sockets *s);
 int close_adapter_for_socket(sockets *s);
 int compare_tunning_parameters(int aid, transponder *tp);
+int check_adapter_restrictions(adapter *ad, int services, int pids, int bandwith);
 void request_adapter_close(adapter *ad);
 int compare_slave_parameters(adapter *ad, transponder *tp);
 int get_absolute_source_for_adapter(int aid, int src, int sys);

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -139,10 +139,12 @@ int rtsp, http, si, si1, ssdp1;
 #define SENDALLECM_OPT (LONG_OPT_ONLY_START + 2)
 #define SATIPC_RECV_BUFFER_OPT (LONG_OPT_ONLY_START + 3)
 #define CLIENT_SEND_BUFFER_OPT (LONG_OPT_ONLY_START + 4)
+#define ADAPTER_RESTRICTIONS_OPT (LONG_OPT_ONLY_START + 5)
 
 static const struct option long_options[] = {
     {"adapters", required_argument, NULL, ADAPTERS_OPT},
     {"adapter-timeout", required_argument, NULL, ADAPTERTIMEOUT_OPT},
+    {"adapter-restrictions", required_argument, NULL, ADAPTER_RESTRICTIONS_OPT},
     {"app-buffer", required_argument, NULL, APPBUFFER_OPT},
     {"buffer", required_argument, NULL, DVRBUFFER_OPT},
     {"bind", required_argument, NULL, BIND_OPT},
@@ -328,6 +330,10 @@ Help\n\
 * -a --adapters x:y:z simulate x DVB-S2, y DVB-T2 and z DVB-C adapters on this box (0 means auto-detect)\n\
 	* eg: -a 1:2:3  \n\
 	- it will report 1 dvb-s2 device, 2 dvb-t2 devices and 3 dvb-c devices \n\
+\n\
+* --adapter-restrictions ADAPTER1[-END1]:MAX-SERVICES:MAX-PIDS:MAX-BANDWITH[,...]: sets requirements of the adapter\n\
+	* eg: --adapter-restrictions 1-2:8:-1:-1,3:-1:20:-1,4-6:3:20:20000\n\
+\t* Note: -1 indicates no limit (default value for all adapters)\n\
 \n\
 * -G --disable-ssdp disable SSDP announcement\n \
 \n\
@@ -958,6 +964,11 @@ void set_options(int argc, char *argv[]) {
 #endif
         case ADAPTERTIMEOUT_OPT: {
             set_timeout_adapters(optarg);
+            break;
+        }
+
+        case ADAPTER_RESTRICTIONS_OPT: {
+            set_restrictions_adapters(optarg);
             break;
         }
 

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -2374,6 +2374,22 @@ char *get_pmt_for_adapter(int aid, char *dest, int max_size) {
     return dest;
 }
 
+int get_channels_for_adapter(adapter *ad) {
+    int i;
+    int num_ch = 0;
+    if (!ad)
+        return num_ch;
+
+    for (i = 0; i < ad->active_pmts; i++) {
+        int p = ad->active_pmt[i];
+        SPMT *pmt = get_pmt(p);
+        if (pmt && pmt->state == PMT_RUNNING)
+            num_ch++;
+    }
+
+    return num_ch;
+}
+
 void free_all_pmts(void) {
     int i;
     for (i = 0; i < MAX_PMT; i++) {

--- a/src/pmt.h
+++ b/src/pmt.h
@@ -230,6 +230,7 @@ void update_cw(SPMT *pmt);
 int pmt_decrypt_stream(adapter *ad);
 int wait_pusi(adapter *ad, int len);
 int pmt_add_ca_descriptor(SPMT *pmt, uint8_t *buf, int sca_id);
+int get_channels_for_adapter(adapter *ad);
 void free_filters();
 void stop_pmt(SPMT *pmt, adapter *ad);
 #endif


### PR DESCRIPTION
A new parameter called "--adapter-restrictions" is added to enforce some adapter limitations when selecting a free tuner. The three limits are (in order of checking): number of used services, number of total pids, consumed bandwith. By default for all adapters the limits are "-1:-1:-1". But if you want to limit the adapter #1 to three simultaneous services only use "1:3:-1:-1".

Note: The calculation of the current bandwith is not currently implemented. Therefore it really doesn't work.