### PR TITLE
Emulate pids all locally when using satipc

### DIFF
--- a/src/adapter.cpp
+++ b/src/adapter.cpp
@@ -2074,7 +2074,7 @@ int signal_thread(sockets *s __attribute__((unused))) {
     return 0;
 }
 
-char *get_adapter_pids(int aid, char *dest, int max_size) {
+char *get_adapter_pids(int aid, char *dest, int max_size, int emu_all) {
     int len = 0;
     int i;
     adapter *ad = get_adapter_nw(aid);
@@ -2086,9 +2086,13 @@ char *get_adapter_pids(int aid, char *dest, int max_size) {
     for (i = 0; i < MAX_PIDS; i++)
         if (ad->pids[i].flags == 1 || ad->pids[i].flags == 2) {
             int pid = ad->pids[i].pid;
-            if (pid == 8192) {
-                strlcatf(dest, max_size, len, "all,");
-                break;
+			if (pid == 8192) {
+                if (!emu_all) {
+                    strlcatf(dest, max_size, len, "all,");
+                    break;
+                } else
+                    strlcatf(dest, max_size, len, "0,1,");
+                    continue;
             } else
                 strlcatf(dest, max_size, len, "%d,", pid);
         }

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -174,7 +174,7 @@ int get_lnb_int_freq(transponder *tp, diseqc *diseqc_param);
 int delsys_match(adapter *ad, int del_sys);
 int get_enabled_pids(adapter *ad, int *pids, int lpids);
 int get_all_pids(adapter *ad, int *pids, int lpids);
-char *get_adapter_pids(int aid, char *dest, int max_size);
+char *get_adapter_pids(int aid, char *dest, int max_size, int emu_all);
 int adapter_timeout(sockets *s);
 void adapter_set_dvr(adapter *ad);
 char is_adapter_disabled(int i);

--- a/src/satipc.cpp
+++ b/src/satipc.cpp
@@ -1338,7 +1338,7 @@ void satipc_get_pids(adapter *ad, satipc *sip, char *url, int size,
     if (!sip->lap && !sip->ldp)
         send_pids = 1;
 
-    get_adapter_pids(ad->id, tmp_url, sizeof(tmp_url));
+    get_adapter_pids(ad->id, tmp_url, sizeof(tmp_url), opts.emulate_pids_all);
     if ((!strcmp(tmp_url, "all") || !strcmp(tmp_url, "none"))) {
         send_pids = 1;
     }


### PR DESCRIPTION
When using the satipc module with "no_pids_all" enabled, it has sense that with "emulate_pids_all" enabled the pids emulation processing will be done locally. So instead of sending "pids=all" the request contains the full pids list.

This patch fixes this issue. Therefore, you don't need that the target SAT>IP box have real "pids=all" support. Using `-k -s ~satip_server` will be sufficient.
 